### PR TITLE
Update identifier handling across components to prioritize global_id …

### DIFF
--- a/src/components/CostUploader/BimMapper.tsx
+++ b/src/components/CostUploader/BimMapper.tsx
@@ -128,7 +128,7 @@ const BimMapper = ({
       const adaptedElements: AdaptedBimElement[] = ifcElements.map(
         (element) => ({
           ...element,
-          id: element._id,
+          id: element.global_id || element._id,
           ebkpCode:
             element.classification?.id || element.properties?.ebkph || "",
         })

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -489,8 +489,8 @@ const MainPage = () => {
               </TableHead>
               <TableBody>
                 {filteredElements.map((element) => (
-                  <TableRow key={element._id}>
-                    <TableCell>{element._id.substring(0, 6)}...</TableCell>
+                    <TableRow key={element.global_id || element._id}>
+                    <TableCell>{(element.global_id || element._id).substring(0, 6)}...</TableCell>
                     <TableCell>
                       {element.type_name ||
                         element.element_type ||

--- a/src/contexts/KafkaContext.tsx
+++ b/src/contexts/KafkaContext.tsx
@@ -534,7 +534,7 @@ export const KafkaProvider: React.FC<KafkaProviderProps> = ({ children }) => {
     }
 
     return {
-      id: element._id,
+      id: element.global_id || element._id, // Use global_id as primary identifier, fallback to _id only if empty
       ebkpCode: ebkpCode,
       quantity: element.quantity,
       area: area,

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -1,7 +1,6 @@
 export interface MongoElement {
   _id: string;
   project_id: string;
-  ifc_id?: string;
   global_id?: string;
   ifc_class?: string;
   name?: string;


### PR DESCRIPTION
…over _id. Adjust MainPage, BimMapper, and KafkaContext to ensure consistent usage of global_id. Remove unused ifc_id from MongoElement type.