### PR TITLE
Fix cost totals computation and add regression tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build --mode production",
     "build:test": "tsc -b && vite build --mode test",
     "lint": "eslint .",
-    "preview": "vite preview --mode production"
+    "preview": "vite preview --mode production",
+    "test": "node --test tests/costCalculations.test.js"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/src/components/CostUploader/CostTableGrandchildRow.tsx
+++ b/src/components/CostUploader/CostTableGrandchildRow.tsx
@@ -5,6 +5,7 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { CostItem } from "./types";
 import { getColumnStyle } from "./styles";
 import { useApi } from "../../contexts/ApiContext";
+import { computeRowTotal } from "../../utils/costCalculations";
 
 // Define a proper type for cellStyles instead of using any
 interface CellStyles {
@@ -36,8 +37,7 @@ const CostTableGrandchildRow = ({
   totalElements,
 }: CostTableGrandchildRowProps) => {
   // Get the Kafka context
-  const { replaceEbkpPlaceholders, calculateUpdatedChf, formatTimestamp } =
-    useApi();
+  const { replaceEbkpPlaceholders, formatTimestamp } = useApi();
 
   // Check if this item has QTO data from MongoDB
   const hasQtoData = (item: CostItem): boolean => {
@@ -63,16 +63,12 @@ const CostTableGrandchildRow = ({
 
   // Get CHF value - calculate based on area when available
   const getChfValue = () => {
-    // If item has area from MongoDB
-    if (
-      item.area !== undefined &&
-      item.kennwert !== null &&
-      item.kennwert !== undefined
-    ) {
-      return item.area * item.kennwert;
-    }
-
-    return calculateUpdatedChf(item);
+    const quantity = item.area !== undefined ? item.area : item.menge;
+    return computeRowTotal({
+      quantity,
+      unitPrice: item.kennwert,
+      factor: item.factor,
+    });
   };
 
   // Get element count for this item
@@ -293,7 +289,7 @@ const CostTableGrandchildRow = ({
               />
             </Tooltip>
           ) : (
-            <>{renderNumber(item.totalChf)}</>
+            <>{renderNumber(getChfValue())}</>
           )}
         </Box>
       </TableCell>

--- a/src/components/CostUploader/PreviewModal.tsx
+++ b/src/components/CostUploader/PreviewModal.tsx
@@ -31,6 +31,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import WarningIcon from "@mui/icons-material/Warning";
 import InfoIcon from "@mui/icons-material/Info";
 import { MetaFile, CostItem } from "./types";
+import { computeRowTotal } from "../../utils/costCalculations";
 import { useApi } from "../../contexts/ApiContext";
 
 // Define a more specific type for the enhanced data passed to onConfirm
@@ -548,8 +549,12 @@ const PreviewModal: React.FC<PreviewModalProps> = ({
       if (!groups[groupKey]) {
         groups[groupKey] = 0;
       }
-      // Sum the final chf of this leaf item
-      groups[groupKey] += item.chf || item.totalChf || 0;
+      const quantity = item.area !== undefined ? item.area : item.menge;
+      groups[groupKey] += computeRowTotal({
+        quantity,
+        unitPrice: item.kennwert,
+        factor: item.factor,
+      });
     });
 
     // Filter out zero values before returning
@@ -587,7 +592,11 @@ const PreviewModal: React.FC<PreviewModalProps> = ({
         const bimMappedArea = costItem.area !== undefined ? costItem.area : 0; // Area/Quantity from BIM mapping
         const unitCost =
           costItem.kennwert !== undefined ? costItem.kennwert : 0; // Unit cost from Excel
-        const totalItemCost = costItem.chf !== undefined ? costItem.chf : 0; // Total CHF for this item, after BIM mapping
+        const totalItemCost = computeRowTotal({
+          quantity: bimMappedArea,
+          unitPrice: unitCost,
+          factor: costItem.factor,
+        });
 
         // Create a QTO-based object with cost data
         return {

--- a/src/components/CostUploader/types.ts
+++ b/src/components/CostUploader/types.ts
@@ -27,6 +27,8 @@ export interface CostItem {
 
   /** Unit cost (per unit of measurement) */
   kennwert?: number;
+  /** Optional multiplication factor */
+  factor?: number;
   /** Total cost value in CHF */
   chf?: number;
   /** Alternative unit cost field */

--- a/src/components/CostUploader/types.tsx
+++ b/src/components/CostUploader/types.tsx
@@ -10,6 +10,7 @@ export interface CostItem {
   ebkp?: string;
   bezeichnung?: string;
   kennwert?: number;
+  factor?: number;
   menge?: number;
   einheit?: string;
   totalChf?: number;
@@ -62,6 +63,7 @@ export interface EnhancedCostItem extends CostItem {
   menge: number;
   totalChf: number;
   kennwert: number;
+  factor: number;
   bezeichnung: string;
   originalItem?: Partial<CostItem>; // Make originalItem optional and partial
 }

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -7,6 +7,7 @@ import React, {
   useCallback,
 } from "react";
 import logger from '../utils/logger';
+import { computeRowTotal } from '../utils/costCalculations';
 import { CostItem } from "../components/CostUploader/types";
 import { costApi } from "../services/costApi";
 import type { BackendElement as ApiBackendElement } from "../services/costApi";
@@ -254,8 +255,12 @@ export const ApiProvider: React.FC<ApiProviderProps> = ({ children }) => {
 
   // Function to calculate updated CHF value
   const calculateUpdatedChf = (item: CostItem): number => {
-    if (!item.menge || !item.kennwert) return 0;
-    return item.menge * item.kennwert;
+    const quantity = item.area !== undefined ? item.area : item.menge;
+    return computeRowTotal({
+      quantity,
+      unitPrice: item.kennwert,
+      factor: item.factor,
+    });
   };
 
   // Function to format timestamp

--- a/src/utils/costCalculations.ts
+++ b/src/utils/costCalculations.ts
@@ -1,0 +1,16 @@
+export interface RowCalculationParams {
+  quantity?: number | null;
+  unitPrice?: number | null;
+  factor?: number | null;
+}
+
+export function computeRowTotal({ quantity, unitPrice, factor }: RowCalculationParams): number {
+  const q = typeof quantity === 'number' ? quantity : 0;
+  const p = typeof unitPrice === 'number' ? unitPrice : 0;
+  const f = typeof factor === 'number' ? factor : 1;
+  return q * p * f;
+}
+
+export function computeGroupTotal(rows: RowCalculationParams[]): number {
+  return rows.reduce((sum, row) => sum + computeRowTotal(row), 0);
+}

--- a/tests/costCalculations.test.js
+++ b/tests/costCalculations.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+
+const source = readFileSync(new URL('../src/utils/costCalculations.ts', import.meta.url), 'utf8');
+const { outputText } = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.ES2020, target: ts.ScriptTarget.ES2020 } });
+const mod = await import(`data:text/javascript;base64,${Buffer.from(outputText).toString('base64')}`);
+const { computeRowTotal, computeGroupTotal } = mod;
+
+test('row total equals quantity * unit price * factor', () => {
+  const total = computeRowTotal({ quantity: 2, unitPrice: 5, factor: 3 });
+  assert.strictEqual(total, 30);
+});
+
+test('group total equals sum of child row totals', () => {
+  const rows = [
+    { quantity: 2, unitPrice: 5, factor: 1 },
+    { quantity: 3, unitPrice: 4, factor: 2 },
+  ];
+  const groupTotal = computeGroupTotal(rows);
+  assert.strictEqual(
+    groupTotal,
+    computeRowTotal(rows[0]) + computeRowTotal(rows[1])
+  );
+});
+
+test('totals recompute after input change (simulate toggle)', () => {
+  const rows = [{ quantity: 1, unitPrice: 10, factor: 1 }];
+  let total = computeGroupTotal(rows);
+  assert.strictEqual(total, 10);
+  // change quantity
+  rows[0].quantity = 2;
+  total = computeGroupTotal(rows);
+  assert.strictEqual(total, 20);
+});
+
+test('regression: ignores stale totals in data', () => {
+  const row = { quantity: 1, unitPrice: 10, factor: 1, chf: 5 };
+  const row2 = { quantity: 1, unitPrice: 5, factor: 1, totalChf: 99 };
+  const total = computeGroupTotal([row, row2]);
+  assert.strictEqual(total, 15);
+});
+


### PR DESCRIPTION
## Summary
- centralize row and group total calculations
- recompute totals in cost table UI instead of using stale values
- add unit tests for row, group and regression scenarios

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / no-unused-vars / etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68adf1f330608320992ed4afb4fec083