### PR TITLE
Fix inconsistent cost totals and add tests

### DIFF
--- a/src/components/CostUploader/CostEbkpGroupRow.tsx
+++ b/src/components/CostUploader/CostEbkpGroupRow.tsx
@@ -11,6 +11,7 @@ import {
   Collapse,
   FormControl,
   IconButton,
+  InputAdornment,
   MenuItem,
   Select,
   SelectChangeEvent,
@@ -145,7 +146,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
   // Memoize filtered and sorted elements for performance
   const processedElements = useMemo(() => {
     // Filter elements if showing only failing ones
-    let filteredElements = showOnlyFailing
+    const filteredElements = showOnlyFailing
       ? group.elements.filter(element => isZeroQuantity(getElementQuantityValue(element, selectedQuantityType)))
       : [...group.elements];
 
@@ -262,7 +263,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
           <TableCell sx={{ py: 1.5, textAlign: "right" }}>
             <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 0.5 }}>
               <Typography variant="body2" sx={{
-                fontWeight: hasZeroQuantity ? 'bold' : 'medium',
+                fontWeight: hasZeroQuantity ? 'bold' : 500,
                 color: hasZeroQuantity ? 'warning.main' : 'inherit'
               }}>
                 {formatQuantity(selectedQuantity.value)} {selectedQuantity.unit}
@@ -299,7 +300,11 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
               size="small"
               sx={{ width: 120 }}
               InputProps={{
-                endAdornment: <Typography variant="caption" color="text.secondary">CHF</Typography>,
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <Typography variant="caption" color="text.secondary">CHF</Typography>
+                  </InputAdornment>
+                ),
               }}
             />
           </TableCell>
@@ -377,7 +382,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                                   <Typography variant="caption" sx={{
                                     color: elementHasZeroQuantity ? 'warning.main' : 'text.secondary',
-                                    fontWeight: elementHasZeroQuantity ? 'bold' : 'medium',
+                                    fontWeight: elementHasZeroQuantity ? 'bold' : 500,
                                     fontSize: '0.8rem'
                                   }}>
                                     {element.type_name || element.ifc_class || 'Unknown'}
@@ -409,6 +414,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                                     <Tooltip title={`GUID kopieren: ${element.global_id}`} arrow>
                                       <IconButton
                                         size="small"
+                                        aria-label={`GUID kopieren${element.global_id ? `: ${element.global_id}` : ''}`}
                                         onClick={() => {
                                           if (element.global_id) {
                                             copyToClipboard(element.global_id);

--- a/src/components/CostUploader/CostEbkpGroupRow.tsx
+++ b/src/components/CostUploader/CostEbkpGroupRow.tsx
@@ -122,7 +122,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
         return { value: selected.value, unit: selected.unit };
       }
     }
-    
+
     const defaultQty = group.availableQuantities[0];
     return defaultQty ? { value: defaultQty.value, unit: defaultQty.unit } : { value: 0, unit: '' };
   };
@@ -138,14 +138,14 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
     const quantityValue = getElementQuantityValue(element, selectedQuantityType);
     return isZeroQuantity(quantityValue);
   });
-  
+
   const hasZeroQuantity = elementsWithZeroQuantity.length > 0;
   const elementsWithMissingQuantities = elementsWithZeroQuantity.length;
-  
-   // Memoize filtered and sorted elements for performance
+
+  // Memoize filtered and sorted elements for performance
   const processedElements = useMemo(() => {
     // Filter elements if showing only failing ones
-    let filteredElements = showOnlyFailing 
+    let filteredElements = showOnlyFailing
       ? group.elements.filter(element => isZeroQuantity(getElementQuantityValue(element, selectedQuantityType)))
       : [...group.elements];
 
@@ -153,15 +153,15 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
     const sortedElements = filteredElements.sort((a, b) => {
       const aHasMissingQuantity = isZeroQuantity(getElementQuantityValue(a, selectedQuantityType));
       const bHasMissingQuantity = isZeroQuantity(getElementQuantityValue(b, selectedQuantityType));
-      
+
       // Elements with missing quantities come first
       if (aHasMissingQuantity && !bHasMissingQuantity) return -1;
       if (!aHasMissingQuantity && bHasMissingQuantity) return 1;
-      
+
       // If both have same status, maintain original order
       return 0;
     });
-    
+
     // Show either first 5 or all elements based on showAllElements state
     return (showAllElements || showOnlyFailing) ? sortedElements : sortedElements.slice(0, 5);
   }, [group.elements, selectedQuantityType, showOnlyFailing, showAllElements]);
@@ -185,47 +185,47 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
       </Snackbar>
 
       {/* Main Group Row */}
-      <Tooltip 
+      <Tooltip
         title={hasZeroQuantity ? `Enthält ${elementsWithMissingQuantities} Element${elementsWithMissingQuantities !== 1 ? 'e' : ''} ohne Mengen - Gruppe ${group.code}` : ''}
         arrow
         placement="left"
       >
-      <TableRow 
-          sx={getZeroQuantityStyles(hasZeroQuantity, { 
-          backgroundColor: isSubGroup ? "rgba(0, 0, 0, 0.02)" : "inherit",
-          "&:hover": { backgroundColor: "rgba(0, 0, 0, 0.04)" },
+        <TableRow
+          sx={getZeroQuantityStyles(hasZeroQuantity, {
+            backgroundColor: isSubGroup ? "rgba(0, 0, 0, 0.02)" : "inherit",
+            "&:hover": { backgroundColor: "rgba(0, 0, 0, 0.04)" },
           })}
-      >
+        >
           <TableCell sx={{ py: 1.5, pl: hasZeroQuantity ? (isSubGroup ? 2.5 : 0.5) : (isSubGroup ? 3 : 1) }}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-            {group.elements.length > 0 && (
-              <IconButton
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              {group.elements.length > 0 && (
+                <IconButton
+                  size="small"
+                  onClick={() => toggleExpand(group.code)}
+                  sx={{ p: 0.5 }}
+                >
+                  {isExpanded ? (
+                    <KeyboardArrowDownIcon fontSize="small" />
+                  ) : (
+                    <KeyboardArrowRightIcon fontSize="small" />
+                  )}
+                </IconButton>
+              )}
+              <Chip
+                label={group.code}
+                color="primary"
+                variant="outlined"
                 size="small"
-                onClick={() => toggleExpand(group.code)}
-                sx={{ p: 0.5 }}
-              >
-                {isExpanded ? (
-                  <KeyboardArrowDownIcon fontSize="small" />
-                ) : (
-                  <KeyboardArrowRightIcon fontSize="small" />
-                )}
-              </IconButton>
-            )}
-            <Chip 
-              label={group.code}
-              color="primary"
-              variant="outlined"
-              size="small"
-              sx={{ fontWeight: 'bold' }}
-            />
-            {group.elements.length > 0 && (
+                sx={{ fontWeight: 'bold' }}
+              />
+              {group.elements.length > 0 && (
                 <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
-              <Typography variant="caption" color="text.secondary">
-                {group.elements.length} Element{group.elements.length !== 1 ? 'e' : ''}
-              </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {group.elements.length} Element{group.elements.length !== 1 ? 'e' : ''}
+                  </Typography>
                   {elementsWithMissingQuantities > 0 && (
-                    <Typography variant="caption" sx={{ 
-                      color: 'warning.main', 
+                    <Typography variant="caption" sx={{
+                      color: 'warning.main',
                       fontWeight: 'bold',
                       fontSize: '0.65rem'
                     }}>
@@ -243,7 +243,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                             setShowAllElements(true); // Show all when filtering to failing
                           }
                         }}
-                        sx={{ 
+                        sx={{
                           fontSize: '0.6rem',
                           py: 0.25,
                           px: 0.75,
@@ -255,72 +255,72 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                     </Box>
                   )}
                 </Box>
-            )}
-          </Box>
-        </TableCell>
-        
-        <TableCell sx={{ py: 1.5, textAlign: "right" }}>
-          <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 0.5 }}>
-              <Typography variant="body2" sx={{ 
+              )}
+            </Box>
+          </TableCell>
+
+          <TableCell sx={{ py: 1.5, textAlign: "right" }}>
+            <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 0.5 }}>
+              <Typography variant="body2" sx={{
                 fontWeight: hasZeroQuantity ? 'bold' : 'medium',
                 color: hasZeroQuantity ? 'warning.main' : 'inherit'
               }}>
-              {formatQuantity(selectedQuantity.value)} {selectedQuantity.unit}
+                {formatQuantity(selectedQuantity.value)} {selectedQuantity.unit}
+              </Typography>
+
+              {group.availableQuantities.length > 1 && (
+                <FormControl size="small" sx={{ minWidth: 80 }}>
+                  <Select
+                    value={group.selectedQuantityType || group.availableQuantities[0]?.type || ''}
+                    onChange={handleQuantityTypeChange}
+                    variant="outlined"
+                    sx={{ fontSize: '0.75rem' }}
+                  >
+                    {group.availableQuantities.map((qty) => (
+                      <MenuItem key={qty.type} value={qty.type}>
+                        {qty.type === 'area' ? 'Fläche' :
+                          qty.type === 'length' ? 'Länge' :
+                            qty.type === 'volume' ? 'Volumen' :
+                              qty.type === 'count' ? 'Stück' : qty.type}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
+            </Box>
+          </TableCell>
+
+          <TableCell sx={{ py: 1.5, textAlign: "right" }}>
+            <TextField
+              type="number"
+              value={kennwert}
+              onChange={handleKennwertChange}
+              variant="outlined"
+              size="small"
+              sx={{ width: 120 }}
+              InputProps={{
+                endAdornment: <Typography variant="caption" color="text.secondary">CHF</Typography>,
+              }}
+            />
+          </TableCell>
+
+          <TableCell sx={{ py: 1.5, textAlign: "right" }}>
+            <Typography variant="subtitle2" fontWeight="bold">
+              {formatCurrency(totalCost)}
             </Typography>
-            
-            {group.availableQuantities.length > 1 && (
-              <FormControl size="small" sx={{ minWidth: 80 }}>
-                <Select
-                  value={group.selectedQuantityType || group.availableQuantities[0]?.type || ''}
-                  onChange={handleQuantityTypeChange}
-                  variant="outlined"
-                  sx={{ fontSize: '0.75rem' }}
-                >
-                  {group.availableQuantities.map((qty) => (
-                    <MenuItem key={qty.type} value={qty.type}>
-                      {qty.type === 'area' ? 'Fläche' : 
-                       qty.type === 'length' ? 'Länge' : 
-                       qty.type === 'volume' ? 'Volumen' : 
-                       qty.type === 'count' ? 'Stück' : qty.type}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            )}
-          </Box>
-        </TableCell>
-        
-        <TableCell sx={{ py: 1.5, textAlign: "right" }}>
-          <TextField
-            type="number"
-            value={kennwert}
-            onChange={handleKennwertChange}
-            variant="outlined"
-            size="small"
-            sx={{ width: 120 }}
-            InputProps={{
-              endAdornment: <Typography variant="caption" color="text.secondary">CHF</Typography>,
-            }}
-          />
-        </TableCell>
-        
-        <TableCell sx={{ py: 1.5, textAlign: "right" }}>
-          <Typography variant="subtitle2" fontWeight="bold">
-            {formatCurrency(totalCost)}
-          </Typography>
-        </TableCell>
-      </TableRow>
+          </TableCell>
+        </TableRow>
       </Tooltip>
 
       {/* Collapsible Elements */}
       {group.elements.length > 0 && (
         <TableRow>
-          <TableCell 
-            colSpan={4} 
-            sx={{ 
-              py: 0, 
+          <TableCell
+            colSpan={4}
+            sx={{
+              py: 0,
               border: "none",
-              backgroundColor: "rgba(0, 0, 0, 0.01)" 
+              backgroundColor: "rgba(0, 0, 0, 0.01)"
             }}
           >
             <Collapse in={isExpanded} timeout="auto" unmountOnExit>
@@ -331,9 +331,9 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                       // For individual elements, check if they have zero quantity for the selected type
                       const quantityValue = getElementQuantityValue(element, selectedQuantityType);
                       const elementHasZeroQuantity = isZeroQuantity(quantityValue);
-                      
+
                       return (
-                        <Tooltip 
+                        <Tooltip
                           key={element._id}
                           title={
                             <Box sx={{ p: 0.5 }}>
@@ -352,9 +352,9 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                               )}
                               {elementHasZeroQuantity && (
                                 <Typography variant="caption" sx={{ display: 'block', color: 'warning.light', fontWeight: 'bold' }}>
-                                  ⚠ Keine {selectedQuantityType === 'area' ? 'Fläche' : 
-                                           selectedQuantityType === 'length' ? 'Länge' : 
-                                           selectedQuantityType === 'volume' ? 'Volumen' : 'Menge'} vorhanden
+                                  ⚠ Keine {selectedQuantityType === 'area' ? 'Fläche' :
+                                    selectedQuantityType === 'length' ? 'Länge' :
+                                      selectedQuantityType === 'volume' ? 'Volumen' : 'Menge'} vorhanden
                                 </Typography>
                               )}
                               <Typography variant="caption" sx={{ display: 'block', fontSize: '0.65rem', mt: 0.5 }}>
@@ -375,30 +375,30 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
                                 {/* Main element info */}
                                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                  <Typography variant="caption" sx={{ 
+                                  <Typography variant="caption" sx={{
                                     color: elementHasZeroQuantity ? 'warning.main' : 'text.secondary',
                                     fontWeight: elementHasZeroQuantity ? 'bold' : 'medium',
                                     fontSize: '0.8rem'
                                   }}>
                                     {element.type_name || element.ifc_class || 'Unknown'}
                                   </Typography>
-                                  
+
                                   {/* Status badges */}
                                   <Box sx={{ display: 'flex', gap: 0.5 }}>
                                     {element.is_structural && (
-                                      <Chip 
-                                        label="Tragwerk" 
-                                        size="small" 
-                                        color="primary" 
+                                      <Chip
+                                        label="Tragwerk"
+                                        size="small"
+                                        color="primary"
                                         variant="outlined"
                                         sx={{ fontSize: '0.6rem', height: 16 }}
                                       />
                                     )}
                                     {element.is_external && (
-                                      <Chip 
-                                        label="Extern" 
-                                        size="small" 
-                                        color="secondary" 
+                                      <Chip
+                                        label="Extern"
+                                        size="small"
+                                        color="secondary"
                                         variant="outlined"
                                         sx={{ fontSize: '0.6rem', height: 16 }}
                                       />
@@ -418,8 +418,8 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                                             setShowToast(true);
                                           }
                                         }}
-                                        sx={{ 
-                                          p: 0.25, 
+                                        sx={{
+                                          p: 0.25,
                                           fontSize: '0.7rem',
                                           color: 'text.secondary',
                                           '&:hover': {
@@ -436,7 +436,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
 
                                 {/* Element name if different from type */}
                                 {element.name && element.name !== element.type_name && (
-                                  <Typography variant="caption" sx={{ 
+                                  <Typography variant="caption" sx={{
                                     color: 'text.secondary',
                                     fontSize: '0.7rem',
                                     fontStyle: 'italic'
@@ -448,7 +448,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                                 {/* Quantities info */}
                                 <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
                                   {element.area !== undefined && (
-                                    <Typography variant="caption" sx={{ 
+                                    <Typography variant="caption" sx={{
                                       color: selectedQuantityType === 'area' && elementHasZeroQuantity ? 'warning.main' : 'text.secondary',
                                       fontSize: '0.65rem',
                                       fontWeight: selectedQuantityType === 'area' ? 'bold' : 'normal'
@@ -457,7 +457,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                                     </Typography>
                                   )}
                                   {element.length !== undefined && (
-                                    <Typography variant="caption" sx={{ 
+                                    <Typography variant="caption" sx={{
                                       color: selectedQuantityType === 'length' && elementHasZeroQuantity ? 'warning.main' : 'text.secondary',
                                       fontSize: '0.65rem',
                                       fontWeight: selectedQuantityType === 'length' ? 'bold' : 'normal'
@@ -466,7 +466,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                                     </Typography>
                                   )}
                                   {element.volume !== undefined && (
-                                    <Typography variant="caption" sx={{ 
+                                    <Typography variant="caption" sx={{
                                       color: selectedQuantityType === 'volume' && elementHasZeroQuantity ? 'warning.main' : 'text.secondary',
                                       fontSize: '0.65rem',
                                       fontWeight: selectedQuantityType === 'volume' ? 'bold' : 'normal'
@@ -480,13 +480,13 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                                 {element.materials && element.materials.length > 0 && (
                                   <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
                                     {element.materials.slice(0, 2).map((material, idx) => (
-                                      <Chip 
+                                      <Chip
                                         key={idx}
-                                        label={material.name} 
-                                        size="small" 
+                                        label={material.name}
+                                        size="small"
                                         variant="outlined"
-                                        sx={{ 
-                                          fontSize: '0.6rem', 
+                                        sx={{
+                                          fontSize: '0.6rem',
                                           height: 16,
                                           color: 'text.secondary',
                                           borderColor: 'rgba(0,0,0,0.12)'
@@ -494,7 +494,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                                       />
                                     ))}
                                     {element.materials.length > 2 && (
-                                      <Typography variant="caption" sx={{ 
+                                      <Typography variant="caption" sx={{
                                         color: 'text.secondary',
                                         fontSize: '0.6rem',
                                         alignSelf: 'center'
@@ -512,7 +512,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                                   {element.level || 'Unbekannte Ebene'}
                                 </Typography>
                                 {element.classification && (
-                                  <Typography variant="caption" sx={{ 
+                                  <Typography variant="caption" sx={{
                                     color: 'text.secondary',
                                     fontSize: '0.65rem',
                                     textAlign: 'right'
@@ -533,9 +533,9 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                         <TableCell sx={{ py: 0.5, border: "none" }}>
                           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                             <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                          <Typography variant="caption" color="text.secondary">
+                              <Typography variant="caption" color="text.secondary">
                                 ... und {group.elements.length - 5} weitere
-                          </Typography>
+                              </Typography>
                               {(() => {
                                 // Count remaining elements with missing quantities
                                 const remainingElements = group.elements.slice(5);
@@ -543,15 +543,15 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                                   const quantityValue = getElementQuantityValue(element, selectedQuantityType);
                                   return isZeroQuantity(quantityValue);
                                 }).length;
-                                
+
                                 return remainingWithMissingQuantities > 0 ? (
-                                  <Typography variant="caption" sx={{ 
-                                    color: 'warning.main', 
+                                  <Typography variant="caption" sx={{
+                                    color: 'warning.main',
                                     fontWeight: 'bold',
                                     fontSize: '0.6rem'
                                   }}>
                                     {remainingWithMissingQuantities} weitere ohne Mengen
-                          </Typography>
+                                  </Typography>
                                 ) : null;
                               })()}
                             </Box>
@@ -560,7 +560,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                               variant="outlined"
                               onClick={() => setShowAllElements(true)}
                               startIcon={<ExpandMoreIcon />}
-                              sx={{ 
+                              sx={{
                                 fontSize: '0.65rem',
                                 py: 0.25,
                                 px: 1,
@@ -584,7 +584,7 @@ const CostEbkpGroupRow: React.FC<CostEbkpGroupRowProps> = ({
                             variant="outlined"
                             onClick={() => setShowAllElements(false)}
                             startIcon={<ExpandLessIcon />}
-                            sx={{ 
+                            sx={{
                               fontSize: '0.65rem',
                               py: 0.25,
                               px: 1,

--- a/src/components/CostUploader/CostTableChildRow.tsx
+++ b/src/components/CostUploader/CostTableChildRow.tsx
@@ -16,9 +16,9 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { CostItem } from "./types";
 import { getColumnStyle, columnWidths } from "./styles";
 import { tableStyle } from "./styles";
-import CostTableGrandchildRow from "./CostTableGrandchildRow.tsx";
+import CostTableGrandchildRow from "./CostTableGrandchildRow";
 import { useApi } from "../../contexts/ApiContext";
-import { computeItemTotal, aggregateChildTotals } from "../../utils/costTotals";
+import { computeItemTotal, aggregateChildTotals, generateItemSignature } from "../../utils/costTotals";
 
 // Define a proper type for cellStyles instead of using any
 interface CellStyles {
@@ -159,26 +159,13 @@ const CostTableChildRow = ({
     return originalMenge;
   };
 
+  // Generate stable signature for deep change detection
+  const itemSignature = useMemo(() => generateItemSignature(item), [item]);
+
   // Memoized CHF calculation to avoid repeated deep traversals
   const chfValue = useMemo(() => {
     return computeItemTotal(item);
-  }, [
-    item.ebkp,
-    item.kennwert,
-    item.area,
-    item.menge,
-    item.children?.length,
-    // Include child signatures for deep changes
-    item.children && JSON.stringify(
-      item.children.map(child => ({
-        ebkp: child.ebkp,
-        kennwert: child.kennwert,
-        area: child.area,
-        menge: child.menge,
-        hasChildren: !!child.children?.length
-      }))
-    )
-  ]);
+  }, [itemSignature]); // Use stable signature to detect deep changes
 
   // Update the getChfValue function to use memoized value
   const getChfValue = () => {

--- a/src/components/CostUploader/CostTableGrandchildRow.tsx
+++ b/src/components/CostUploader/CostTableGrandchildRow.tsx
@@ -5,7 +5,7 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { CostItem } from "./types";
 import { getColumnStyle } from "./styles";
 import { useApi } from "../../contexts/ApiContext";
-import { computeItemTotal } from "../../utils/costTotals";
+import { computeItemTotal, generateItemSignature } from "../../utils/costTotals";
 
 // Define a proper type for cellStyles instead of using any
 interface CellStyles {
@@ -61,26 +61,13 @@ const CostTableGrandchildRow = ({
     return originalMenge;
   };
 
+  // Generate stable signature for deep change detection
+  const itemSignature = useMemo(() => generateItemSignature(item), [item]);
+
   // Memoized CHF calculation to avoid repeated deep traversals
   const chfValue = useMemo(() => {
     return computeItemTotal(item);
-  }, [
-    item.ebkp,
-    item.kennwert,
-    item.area,
-    item.menge,
-    item.children?.length,
-    // Include child signatures for deep changes
-    item.children && JSON.stringify(
-      item.children.map(child => ({
-        ebkp: child.ebkp,
-        kennwert: child.kennwert,
-        area: child.area,
-        menge: child.menge,
-        hasChildren: !!child.children?.length
-      }))
-    )
-  ]);
+  }, [itemSignature]); // Use stable signature to detect deep changes
 
   // Get CHF value - calculate based on area when available
   const getChfValue = () => {

--- a/src/components/CostUploader/CostTableGrandchildRow.tsx
+++ b/src/components/CostUploader/CostTableGrandchildRow.tsx
@@ -5,6 +5,7 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { CostItem } from "./types";
 import { getColumnStyle } from "./styles";
 import { useApi } from "../../contexts/ApiContext";
+import { computeItemTotal } from "../../utils/costTotals";
 
 // Define a proper type for cellStyles instead of using any
 interface CellStyles {
@@ -36,8 +37,7 @@ const CostTableGrandchildRow = ({
   totalElements,
 }: CostTableGrandchildRowProps) => {
   // Get the Kafka context
-  const { replaceEbkpPlaceholders, calculateUpdatedChf, formatTimestamp } =
-    useApi();
+  const { replaceEbkpPlaceholders, formatTimestamp } = useApi();
 
   // Check if this item has QTO data from MongoDB
   const hasQtoData = (item: CostItem): boolean => {
@@ -63,16 +63,7 @@ const CostTableGrandchildRow = ({
 
   // Get CHF value - calculate based on area when available
   const getChfValue = () => {
-    // If item has area from MongoDB
-    if (
-      item.area !== undefined &&
-      item.kennwert !== null &&
-      item.kennwert !== undefined
-    ) {
-      return item.area * item.kennwert;
-    }
-
-    return calculateUpdatedChf(item);
+    return computeItemTotal(item);
   };
 
   // Get element count for this item
@@ -293,7 +284,7 @@ const CostTableGrandchildRow = ({
               />
             </Tooltip>
           ) : (
-            <>{renderNumber(item.totalChf)}</>
+            <>{renderNumber(getChfValue())}</>
           )}
         </Box>
       </TableCell>

--- a/src/components/CostUploader/CostTableGrandchildRow.tsx
+++ b/src/components/CostUploader/CostTableGrandchildRow.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { TableRow, TableCell, Box, Tooltip, Chip } from "@mui/material";
 import SyncIcon from "@mui/icons-material/Sync";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
@@ -61,9 +61,30 @@ const CostTableGrandchildRow = ({
     return originalMenge;
   };
 
+  // Memoized CHF calculation to avoid repeated deep traversals
+  const chfValue = useMemo(() => {
+    return computeItemTotal(item);
+  }, [
+    item.ebkp,
+    item.kennwert,
+    item.area,
+    item.menge,
+    item.children?.length,
+    // Include child signatures for deep changes
+    item.children && JSON.stringify(
+      item.children.map(child => ({
+        ebkp: child.ebkp,
+        kennwert: child.kennwert,
+        area: child.area,
+        menge: child.menge,
+        hasChildren: !!child.children?.length
+      }))
+    )
+  ]);
+
   // Get CHF value - calculate based on area when available
   const getChfValue = () => {
-    return computeItemTotal(item);
+    return chfValue;
   };
 
   // Get element count for this item

--- a/src/components/CostUploader/CostTableRow.tsx
+++ b/src/components/CostUploader/CostTableRow.tsx
@@ -17,9 +17,9 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { CostItem } from "./types";
 import { getColumnStyle, columnWidths } from "./styles";
 import { tableStyle } from "./styles";
-import CostTableChildRow from "./CostTableChildRow.tsx";
+import CostTableChildRow from "./CostTableChildRow";
 import { useApi } from "../../contexts/ApiContext";
-import { computeItemTotal, aggregateChildTotals } from "../../utils/costTotals";
+import { computeItemTotal, aggregateChildTotals, generateItemSignature } from "../../utils/costTotals";
 
 // Define a proper type for cellStyles instead of using any
 interface CellStyles {
@@ -168,26 +168,13 @@ const CostTableRow = ({
     return originalMenge;
   };
 
+  // Generate stable signature for deep change detection
+  const itemSignature = useMemo(() => generateItemSignature(item), [item]);
+
   // Memoized CHF calculation to avoid repeated deep traversals
   const chfValue = useMemo(() => {
     return computeItemTotal(item);
-  }, [
-    item.ebkp,
-    item.kennwert,
-    item.area,
-    item.menge,
-    item.children?.length,
-    // Include child signatures for deep changes
-    item.children && JSON.stringify(
-      item.children.map(child => ({
-        ebkp: child.ebkp,
-        kennwert: child.kennwert,
-        area: child.area,
-        menge: child.menge,
-        hasChildren: !!child.children?.length
-      }))
-    )
-  ]);
+  }, [itemSignature]); // Use stable signature to detect deep changes
 
   // Update the getChfValue function to use memoized value
   const getChfValue = (): number => {

--- a/src/components/CostUploader/CostTableRow.tsx
+++ b/src/components/CostUploader/CostTableRow.tsx
@@ -112,7 +112,7 @@ const CostTableRow = ({
     if (qtoInTree !== hasQtoInTreeState) {
       setHasQtoInTreeState(qtoInTree);
     }
-  }, [item, hasQtoState, hasQtoInTreeState]);
+  }, [item, hasQtoState, hasQtoInTreeState, qtoInTree]);
 
   // Use state values for rendering
   const hasQtoInTree = hasQtoInTreeState;
@@ -174,7 +174,7 @@ const CostTableRow = ({
   // Memoized CHF calculation to avoid repeated deep traversals
   const chfValue = useMemo(() => {
     return computeItemTotal(item);
-  }, [itemSignature]); // Use stable signature to detect deep changes
+  }, [item, itemSignature]); // Use stable signature to detect deep changes
 
   // Update the getChfValue function to use memoized value
   const getChfValue = (): number => {

--- a/src/components/CostUploader/CostTableRow.tsx
+++ b/src/components/CostUploader/CostTableRow.tsx
@@ -19,6 +19,7 @@ import { getColumnStyle, columnWidths } from "./styles";
 import { tableStyle } from "./styles";
 import CostTableChildRow from "./CostTableChildRow.tsx";
 import { useApi } from "../../contexts/ApiContext";
+import { computeItemTotal } from "../../utils/costTotals";
 
 // Define a proper type for cellStyles instead of using any
 interface CellStyles {
@@ -61,8 +62,7 @@ const CostTableRow = ({
   const [hasQtoInTreeState, setHasQtoInTreeState] = useState<boolean>(false);
 
   // Get the Kafka context
-  const { replaceEbkpPlaceholders, calculateUpdatedChf, formatTimestamp } =
-    useApi();
+  const { replaceEbkpPlaceholders, formatTimestamp } = useApi();
 
   // Update the hasQtoData function to check for IFC data
   const hasQtoData = (item: CostItem): boolean => {
@@ -150,45 +150,25 @@ const CostTableRow = ({
   // Update the calculateTotalsFromChildren function to fix TypeScript errors
   const calculateTotalsFromChildren = (
     item: CostItem
-  ): { area: number; cost: number; elementCount: number } => {
+  ): { area: number; elementCount: number } => {
     if (!item.children || item.children.length === 0) {
-      return { area: 0, cost: 0, elementCount: 0 };
+      return { area: 0, elementCount: 0 };
     }
 
-    return item.children.reduce<{
-      area: number;
-      cost: number;
-      elementCount: number;
-    }>(
+    return item.children.reduce<{ area: number; elementCount: number }>(
       (acc, child) => {
-        // If child has direct area from MongoDB, add it
-        if (child.area !== undefined) {
-          acc.area += child.area;
-          acc.cost += child.area * (child.kennwert || 0);
-          // Only count elements at the leaf level (no children)
-          if (!child.children || child.children.length === 0) {
-            acc.elementCount += child.element_count || 1;
-          }
-        }
-        // If child has its own children, add their totals
         if (child.children && child.children.length > 0) {
           const childTotals = calculateTotalsFromChildren(child);
           acc.area += childTotals.area;
-          acc.cost += childTotals.cost;
           acc.elementCount += childTotals.elementCount;
-        }
-        // If child has no IFC data but has a menge, add it
-        if (child.area === undefined && child.menge !== undefined) {
-          acc.area += child.menge || 0;
-          acc.cost += (child.menge || 0) * (child.kennwert || 0);
-          // Only count non-IFC items at the leaf level
-          if (!child.children || child.children.length === 0) {
-            acc.elementCount += 1;
-          }
+        } else {
+          const qty = child.area ?? child.menge ?? 0;
+          acc.area += qty;
+          acc.elementCount += child.element_count || 1;
         }
         return acc;
       },
-      { area: 0, cost: 0, elementCount: 0 }
+      { area: 0, elementCount: 0 }
     );
   };
 
@@ -210,16 +190,7 @@ const CostTableRow = ({
 
   // Update the getChfValue function to calculate total CHF
   const getChfValue = (): number => {
-    // Calculate total cost from children
-    const { cost } = calculateTotalsFromChildren(item);
-
-    // If we have a total cost from children, use it
-    if (cost > 0) {
-      return cost;
-    }
-
-    // Fallback to original calculation
-    return calculateUpdatedChf(item);
+    return computeItemTotal(item);
   };
 
   // Process text fields to replace any eBKP placeholders
@@ -475,7 +446,7 @@ const CostTableRow = ({
                 />
               </Tooltip>
             ) : (
-              <>{renderNumber(item.totalChf)}</>
+              <>{renderNumber(getChfValue())}</>
             )}
           </Box>
         </TableCell>

--- a/src/components/CostUploader/MainCostEbkpGroupRow.tsx
+++ b/src/components/CostUploader/MainCostEbkpGroupRow.tsx
@@ -135,11 +135,34 @@ const MainCostEbkpGroupRow: React.FC<MainCostEbkpGroupRowProps> = ({
             </Box>
           </TableCell>
           <TableCell sx={{ py: 2, textAlign: "right" }}>
-            <Typography variant="body2" sx={{ 
+            <Typography variant="body2" sx={{
               fontWeight: hasZeroQuantity ? 'bold' : 'medium',
               color: hasZeroQuantity ? 'warning.main' : 'inherit'
             }}>
-              {formatQuantity(group.totalQuantity)} m²
+              {(() => {
+                // Determine the most common unit among subGroups
+                const unitCounts = new Map<string, number>();
+                group.subGroups.forEach(subGroup => {
+                  const selectedType = subGroup.selectedQuantityType || subGroup.availableQuantities[0]?.type;
+                  const selectedQty = subGroup.availableQuantities.find(q => q.type === selectedType);
+                  if (selectedQty) {
+                    const count = unitCounts.get(selectedQty.unit) || 0;
+                    unitCounts.set(selectedQty.unit, count + 1);
+                  }
+                });
+
+                // Get the most common unit
+                let mostCommonUnit = 'm²'; // default fallback
+                let maxCount = 0;
+                unitCounts.forEach((count, unit) => {
+                  if (count > maxCount) {
+                    maxCount = count;
+                    mostCommonUnit = unit;
+                  }
+                });
+
+                return `${formatQuantity(group.totalQuantity)} ${mostCommonUnit}`;
+              })()}
             </Typography>
           </TableCell>
           <TableCell sx={{ py: 2, textAlign: "right" }}>

--- a/src/components/CostUploader/MainCostEbkpGroupRow.tsx
+++ b/src/components/CostUploader/MainCostEbkpGroupRow.tsx
@@ -73,18 +73,55 @@ const MainCostEbkpGroupRow: React.FC<MainCostEbkpGroupRowProps> = ({
     return total + elementsWithZeroQuantity.length;
   }, 0);
 
+  // Memoized unit analysis for consistent units check and most common unit
+  const unitAnalysis = React.useMemo(() => {
+    const units = new Set<string>();
+    let totalSubgroups = 0;
+
+    for (const subGroup of group.subGroups) {
+      const selectedType = subGroup.selectedQuantityType || subGroup.availableQuantities[0]?.type;
+      const selectedQty = subGroup.availableQuantities.find(q => q.type === selectedType);
+      if (selectedQty?.unit) {
+        units.add(selectedQty.unit);
+        totalSubgroups++;
+      }
+    }
+
+    // Check if all subgroups have the same unit
+    const hasUniformUnits = units.size === 1 && totalSubgroups > 0;
+    const uniformUnit = hasUniformUnits ? Array.from(units)[0] : '';
+
+    return {
+      hasUniformUnits,
+      uniformUnit,
+      uniqueUnitsCount: units.size,
+      totalSubgroups
+    };
+  }, [group.subGroups]);
+
+  // Extract values for easier access
+  const { hasUniformUnits, uniformUnit, uniqueUnitsCount, totalSubgroups } = unitAnalysis;
+
   return (
     <>
       {/* Main Group Header Row */}
-      <Tooltip 
-        title={hasZeroQuantity ? `Enthält Elemente ohne Mengen - Hauptgruppe ${group.mainGroup}` : ''}
+      <Tooltip
+        title={
+          hasZeroQuantity
+            ? `Enthält Elemente ohne Mengen - Hauptgruppe ${group.mainGroup}`
+            : !hasUniformUnits && totalSubgroups > 1
+              ? `Verschiedene Einheiten (${uniqueUnitsCount} verschiedene) - Summierung nicht möglich`
+              : hasUniformUnits
+                ? `Einheitliche Einheit: ${uniformUnit}`
+                : ''
+        }
         arrow
         placement="left"
       >
-        <TableRow 
-          sx={getZeroQuantityStyles(hasZeroQuantity, { 
+        <TableRow
+          sx={getZeroQuantityStyles(hasZeroQuantity, {
             backgroundColor: isExpanded ? 'rgba(25, 118, 210, 0.08)' : 'rgba(0, 0, 0, 0.04)',
-            "&:hover": { 
+            "&:hover": {
               backgroundColor: isExpanded ? 'rgba(25, 118, 210, 0.12)' : 'rgba(0, 0, 0, 0.08)'
             },
             cursor: 'pointer',
@@ -115,7 +152,7 @@ const MainCostEbkpGroupRow: React.FC<MainCostEbkpGroupRowProps> = ({
                 {group.mainGroup === "_OTHER_" ? "Sonstige Klassifikationen" : group.mainGroupName}
               </Typography>
               <Box sx={{ ml: 1, display: 'flex', flexDirection: 'column' }}>
-                <Typography variant="body2" sx={{ 
+                <Typography variant="body2" sx={{
                   color: "text.secondary",
                   fontSize: "0.8rem",
                   fontWeight: 500
@@ -123,8 +160,8 @@ const MainCostEbkpGroupRow: React.FC<MainCostEbkpGroupRowProps> = ({
                   {group.subGroups.length} Gruppen • {group.totalElements} Elemente
                 </Typography>
                 {totalElementsWithMissingQuantities > 0 && (
-                  <Typography variant="caption" sx={{ 
-                    color: 'warning.main', 
+                  <Typography variant="caption" sx={{
+                    color: 'warning.main',
                     fontWeight: 'bold',
                     fontSize: '0.65rem'
                   }}>
@@ -136,33 +173,12 @@ const MainCostEbkpGroupRow: React.FC<MainCostEbkpGroupRowProps> = ({
           </TableCell>
           <TableCell sx={{ py: 2, textAlign: "right" }}>
             <Typography variant="body2" sx={{
-              fontWeight: hasZeroQuantity ? 'bold' : 'medium',
+              fontWeight: hasZeroQuantity ? 'bold' : 500,
               color: hasZeroQuantity ? 'warning.main' : 'inherit'
             }}>
-              {(() => {
-                // Determine the most common unit among subGroups
-                const unitCounts = new Map<string, number>();
-                group.subGroups.forEach(subGroup => {
-                  const selectedType = subGroup.selectedQuantityType || subGroup.availableQuantities[0]?.type;
-                  const selectedQty = subGroup.availableQuantities.find(q => q.type === selectedType);
-                  if (selectedQty) {
-                    const count = unitCounts.get(selectedQty.unit) || 0;
-                    unitCounts.set(selectedQty.unit, count + 1);
-                  }
-                });
-
-                // Get the most common unit
-                let mostCommonUnit = 'm²'; // default fallback
-                let maxCount = 0;
-                unitCounts.forEach((count, unit) => {
-                  if (count > maxCount) {
-                    maxCount = count;
-                    mostCommonUnit = unit;
-                  }
-                });
-
-                return `${formatQuantity(group.totalQuantity)} ${mostCommonUnit}`;
-              })()}
+              {hasUniformUnits
+                ? `${formatQuantity(group.totalQuantity)} ${uniformUnit}`
+                : 'Verschiedene Einheiten'}
             </Typography>
           </TableCell>
           <TableCell sx={{ py: 2, textAlign: "right" }}>
@@ -180,12 +196,12 @@ const MainCostEbkpGroupRow: React.FC<MainCostEbkpGroupRowProps> = ({
 
       {/* Collapsible Sub-Groups */}
       <TableRow>
-        <TableCell 
-          colSpan={4} 
-          sx={{ 
-            py: 0, 
+        <TableCell
+          colSpan={4}
+          sx={{
+            py: 0,
             border: "none",
-            backgroundColor: "transparent" 
+            backgroundColor: "transparent"
           }}
         >
           <Collapse in={isExpanded} timeout="auto" unmountOnExit>

--- a/src/components/CostUploader/PreviewModal.tsx
+++ b/src/components/CostUploader/PreviewModal.tsx
@@ -32,6 +32,7 @@ import WarningIcon from "@mui/icons-material/Warning";
 import InfoIcon from "@mui/icons-material/Info";
 import { MetaFile, CostItem } from "./types";
 import { useApi } from "../../contexts/ApiContext";
+import { computeItemTotal } from "../../utils/costTotals";
 
 // Define a more specific type for the enhanced data passed to onConfirm
 // Based on the structure created in handleConfirm
@@ -548,8 +549,8 @@ const PreviewModal: React.FC<PreviewModalProps> = ({
       if (!groups[groupKey]) {
         groups[groupKey] = 0;
       }
-      // Sum the final chf of this leaf item
-      groups[groupKey] += item.chf || item.totalChf || 0;
+      // Sum the total using current unit price and quantity
+      groups[groupKey] += computeItemTotal(item);
     });
 
     // Filter out zero values before returning

--- a/src/components/CostUploader/index.tsx
+++ b/src/components/CostUploader/index.tsx
@@ -311,9 +311,8 @@ const CostUploader = ({
     async function fetchProjects() {
       try {
         await costApi.getProjects();
-        // ... (handle project data)
       } catch (error) {
-        // ... (handle error)
+        logger.error("Failed to fetch projects:", error);
       }
     }
     fetchProjects();

--- a/src/components/EbkpCostForm.tsx
+++ b/src/components/EbkpCostForm.tsx
@@ -36,7 +36,7 @@ import React, { useMemo, useState } from "react";
 import { useEbkpGroups } from "../hooks/useEbkpGroups";
 import { MongoElement } from "../types/common.types";
 import { getZeroQuantityStyles } from "../utils/zeroQuantityHighlight";
-import { hasElementMissingQuantity } from '../utils/quantityUtils';
+import { hasElementMissingQuantity, quantityTypeLabel, quantityTypeCalculationLabel } from '../utils/quantityUtils';
 import MainCostEbkpGroupRow from "./CostUploader/MainCostEbkpGroupRow";
 
 export interface EbkpStat {
@@ -583,10 +583,7 @@ const EbkpCostForm: React.FC<Props> = ({
               >
                 {uniqueQuantityTypes.map((type) => (
                   <MenuItem key={type} value={type}>
-                    {type === 'area' ? 'Fläche' :
-                      type === 'length' ? 'Länge' :
-                        type === 'volume' ? 'Volumen' :
-                          type === 'count' ? 'Stück' : type}
+                    {quantityTypeLabel(type)}
                   </MenuItem>
                 ))}
               </Select>
@@ -765,7 +762,6 @@ const EbkpCostForm: React.FC<Props> = ({
                       p: 3,
                       transition: 'all 0.3s ease-in-out',
                       '&:hover': {
-                        elevation: 4,
                         transform: 'translateY(-2px)',
                         boxShadow: '0 8px 25px rgba(0,0,0,0.15)'
                       },
@@ -815,7 +811,7 @@ const EbkpCostForm: React.FC<Props> = ({
 
                       {/* Quantity Selection */}
                       <Box sx={{ flex: 1, minWidth: 300 }}>
-                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 'medium' }}>
+                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 500 }}>
                           Mengenauswahl
                         </Typography>
                         {group.availableQuantities && group.availableQuantities.length > 1 ? (
@@ -850,14 +846,11 @@ const EbkpCostForm: React.FC<Props> = ({
                                 return (
                                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, width: '100%' }}>
                                     <Box sx={{ flex: 1 }}>
-                                      <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
                                         {selected.label}
                                       </Typography>
                                       <Typography variant="caption" color="text.secondary">
-                                        {selected.type === 'area' ? 'Flächenberechnung' :
-                                          selected.type === 'length' ? 'Längenberechnung' :
-                                            selected.type === 'volume' ? 'Volumenberechnung' :
-                                              selected.type === 'count' ? 'Stückzahl' : 'Andere'}
+                                        {quantityTypeCalculationLabel(selected.type)}
                                       </Typography>
                                     </Box>
                                     <Chip
@@ -892,14 +885,11 @@ const EbkpCostForm: React.FC<Props> = ({
                                 >
                                   <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%', alignItems: 'center' }}>
                                     <Box>
-                                      <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
                                         {qty.label}
                                       </Typography>
                                       <Typography variant="caption" color="text.secondary">
-                                        {qty.type === 'area' ? 'Flächenberechnung' :
-                                          qty.type === 'length' ? 'Längenberechnung' :
-                                            qty.type === 'volume' ? 'Volumenberechnung' :
-                                              qty.type === 'count' ? 'Stückzahl' : 'Andere'}
+                                        {quantityTypeCalculationLabel(qty.type)}
                                       </Typography>
                                     </Box>
                                     <Chip
@@ -926,7 +916,7 @@ const EbkpCostForm: React.FC<Props> = ({
                             justifyContent: 'space-between'
                           }}>
                             <Box>
-                              <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                              <Typography variant="body2" sx={{ fontWeight: 500 }}>
                                 {group.availableQuantities[0].label}
                               </Typography>
                               <Typography variant="caption" color="text.secondary">
@@ -962,7 +952,7 @@ const EbkpCostForm: React.FC<Props> = ({
 
                       {/* Cost Input and Calculation */}
                       <Box sx={{ minWidth: 200 }}>
-                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 'medium' }}>
+                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 500 }}>
                           Kennwert (CHF)
                         </Typography>
                         <TextField
@@ -990,7 +980,7 @@ const EbkpCostForm: React.FC<Props> = ({
 
                       {/* Total Cost Display */}
                       <Box sx={{ minWidth: 150, textAlign: 'right' }}>
-                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 'medium' }}>
+                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 500 }}>
                           Gesamtkosten
                         </Typography>
                         <Box sx={{

--- a/src/components/EbkpCostForm.tsx
+++ b/src/components/EbkpCostForm.tsx
@@ -80,11 +80,11 @@ interface GroupedData {
   selectedQuantityType?: string;
 }
 
-const EbkpCostForm: React.FC<Props> = ({ 
-  stats, 
-  kennwerte, 
-  onKennwertChange, 
-  onQuantityTypeChange, 
+const EbkpCostForm: React.FC<Props> = ({
+  stats,
+  kennwerte,
+  onKennwertChange,
+  onQuantityTypeChange,
   elements = []
 }) => {
   const [searchTerm, setSearchTerm] = useState("");
@@ -94,28 +94,28 @@ const EbkpCostForm: React.FC<Props> = ({
   const [groupingStrategy, setGroupingStrategy] = useState<GroupingStrategy>('ebkp');
   const [quantityTypeFilter, setQuantityTypeFilter] = useState<string[]>([]);
   const [hasKennwertFilter, setHasKennwertFilter] = useState<'all' | 'with' | 'without'>('all');
-  
+
   // Hierarchical table state
   const [expandedMainGroups, setExpandedMainGroups] = useState<string[]>([]);
   const [expandedEbkp, setExpandedEbkp] = useState<string[]>([]);
-  
+
   // Use hierarchical groups hook for EBKP grouping
   const { ebkpGroups, hierarchicalGroups } = useEbkpGroups(stats, kennwerte);
-  
+
 
 
   // Expand/collapse functionality
   const toggleMainGroup = (mainGroup: string) => {
-    setExpandedMainGroups(prev => 
-      prev.includes(mainGroup) 
+    setExpandedMainGroups(prev =>
+      prev.includes(mainGroup)
         ? prev.filter(g => g !== mainGroup)
         : [...prev, mainGroup]
     );
   };
 
   const toggleEbkpGroup = (code: string) => {
-    setExpandedEbkp(prev => 
-      prev.includes(code) 
+    setExpandedEbkp(prev =>
+      prev.includes(code)
         ? prev.filter(c => c !== code)
         : [...prev, code]
     );
@@ -125,18 +125,18 @@ const EbkpCostForm: React.FC<Props> = ({
   const areAllGroupsExpanded = useMemo(() => {
     if (hierarchicalGroups) {
       // Check if all main groups are expanded
-      const allMainGroupsExpanded = hierarchicalGroups.every(group => 
+      const allMainGroupsExpanded = hierarchicalGroups.every(group =>
         expandedMainGroups.includes(group.mainGroup)
       );
-      
+
       // Check if all sub-groups are expanded
-      const allSubGroupsCodes = hierarchicalGroups.flatMap(group => 
+      const allSubGroupsCodes = hierarchicalGroups.flatMap(group =>
         group.subGroups.map(subGroup => subGroup.code)
       );
-      const allSubGroupsExpanded = allSubGroupsCodes.every(code => 
+      const allSubGroupsExpanded = allSubGroupsCodes.every(code =>
         expandedEbkp.includes(code)
       );
-      
+
       return allMainGroupsExpanded && allSubGroupsExpanded;
     } else {
       // For flat view, check if all EBKP groups are expanded
@@ -153,7 +153,7 @@ const EbkpCostForm: React.FC<Props> = ({
       // Expand all
       if (hierarchicalGroups) {
         const allMainGroups = hierarchicalGroups.map(group => group.mainGroup);
-        const allSubGroupsCodes = hierarchicalGroups.flatMap(group => 
+        const allSubGroupsCodes = hierarchicalGroups.flatMap(group =>
           group.subGroups.map(subGroup => subGroup.code)
         );
         setExpandedMainGroups(allMainGroups);
@@ -169,7 +169,7 @@ const EbkpCostForm: React.FC<Props> = ({
   // Helper function to check if a group has missing quantities
   const hasGroupMissingQuantities = (group: GroupedData): boolean => {
     const selectedQuantityType = group.selectedQuantityType || group.availableQuantities[0]?.type;
-    
+
     return group.elements.some(element => {
       return hasElementMissingQuantity(element, selectedQuantityType);
     });
@@ -189,10 +189,10 @@ const EbkpCostForm: React.FC<Props> = ({
     }
 
     const groups = new Map<string, MongoElement[]>();
-    
+
     elements.forEach((element) => {
       let groupKey = '';
-      
+
       switch (groupingStrategy) {
         case 'ifc_class':
           groupKey = element.ifc_class || 'Unknown';
@@ -212,7 +212,7 @@ const EbkpCostForm: React.FC<Props> = ({
         default:
           groupKey = 'Unknown';
       }
-      
+
       if (!groups.has(groupKey)) {
         groups.set(groupKey, []);
       }
@@ -221,9 +221,9 @@ const EbkpCostForm: React.FC<Props> = ({
 
     const result = Array.from(groups.entries()).map(([groupKey, groupElements]) => {
       const availableQuantities = new Map<string, { value: number; unit: string; label: string }>();
-      
-              groupElements.forEach((element) => {
-          if (element.available_quantities && element.available_quantities.length > 0) {
+
+      groupElements.forEach((element) => {
+        if (element.available_quantities && element.available_quantities.length > 0) {
           element.available_quantities.forEach(qty => {
             const existing = availableQuantities.get(qty.type);
             if (existing) {
@@ -236,8 +236,8 @@ const EbkpCostForm: React.FC<Props> = ({
               });
             }
           });
-                  } else {
-            const elementAny = element as MongoElement & { area?: number; length?: number; volume?: number };
+        } else {
+          const elementAny = element as MongoElement & { area?: number; length?: number; volume?: number };
           if (elementAny.area && elementAny.area > 0) {
             const existing = availableQuantities.get('area');
             if (existing) {
@@ -250,8 +250,8 @@ const EbkpCostForm: React.FC<Props> = ({
               });
             }
           }
-          
-          
+
+
           if (elementAny.length && elementAny.length > 0) {
             const existing = availableQuantities.get('length');
             if (existing) {
@@ -264,8 +264,8 @@ const EbkpCostForm: React.FC<Props> = ({
               });
             }
           }
-          
-          
+
+
           if (elementAny.volume && elementAny.volume > 0) {
             const existing = availableQuantities.get('volume');
             if (existing) {
@@ -281,13 +281,13 @@ const EbkpCostForm: React.FC<Props> = ({
         }
       });
 
-              if (!availableQuantities.has('count')) {
-          availableQuantities.set('count', {
-            value: groupElements.length,
-            unit: 'Stk',
-            label: 'Count'
-          });
-        }
+      if (!availableQuantities.has('count')) {
+        availableQuantities.set('count', {
+          value: groupElements.length,
+          unit: 'Stk',
+          label: 'Count'
+        });
+      }
 
       const finalQuantities = Array.from(availableQuantities.entries()).map(([type, data]) => ({
         value: data.value,
@@ -308,7 +308,7 @@ const EbkpCostForm: React.FC<Props> = ({
 
       return groupData;
     });
-    
+
     return result;
   }, [stats, elements, groupingStrategy]);
 
@@ -332,34 +332,34 @@ const EbkpCostForm: React.FC<Props> = ({
   }, [groupedData]);
 
   const filteredAndSortedData = useMemo(() => {
-          const filtered = groupedData.filter(group => {
-        if (searchTerm) {
+    const filtered = groupedData.filter(group => {
+      if (searchTerm) {
         const searchLower = searchTerm.toLowerCase();
         const matchesGroup = group.displayName.toLowerCase().includes(searchLower) ||
-                           group.groupKey.toLowerCase().includes(searchLower);
-        const matchesQuantityType = group.availableQuantities.some(qty => 
-          qty.type.toLowerCase().includes(searchLower) || 
+          group.groupKey.toLowerCase().includes(searchLower);
+        const matchesQuantityType = group.availableQuantities.some(qty =>
+          qty.type.toLowerCase().includes(searchLower) ||
           qty.label.toLowerCase().includes(searchLower)
         );
-        
+
         if (!matchesGroup && !matchesQuantityType) {
           return false;
         }
       }
 
-              if (quantityTypeFilter.length > 0) {
-        const hasFilteredType = group.availableQuantities.some(qty => 
+      if (quantityTypeFilter.length > 0) {
+        const hasFilteredType = group.availableQuantities.some(qty =>
           quantityTypeFilter.includes(qty.type)
         );
-        
+
         if (!hasFilteredType) {
           return false;
         }
       }
 
-              if (hasKennwertFilter !== 'all') {
+      if (hasKennwertFilter !== 'all') {
         const hasKennwert = kennwerte[group.groupKey] && kennwerte[group.groupKey] > 0;
-        
+
         if (hasKennwertFilter === 'with' && !hasKennwert) {
           return false;
         }
@@ -376,13 +376,13 @@ const EbkpCostForm: React.FC<Props> = ({
       // First priority: groups with missing quantities should come first
       const aMissingQuantities = hasGroupMissingQuantities(a);
       const bMissingQuantities = hasGroupMissingQuantities(b);
-      
+
       if (aMissingQuantities && !bMissingQuantities) return -1; // a comes first
       if (!aMissingQuantities && bMissingQuantities) return 1;  // b comes first
-      
+
       // If both have same missing quantity status, sort by the selected field
       let aValue: string | number, bValue: string | number;
-      
+
       switch (sortField) {
         case 'group':
           aValue = a.displayName;
@@ -409,7 +409,7 @@ const EbkpCostForm: React.FC<Props> = ({
       }
 
       if (typeof aValue === 'string' && typeof bValue === 'string') {
-        return sortDirection === 'asc' 
+        return sortDirection === 'asc'
           ? aValue.localeCompare(bValue)
           : bValue.localeCompare(aValue);
       }
@@ -417,7 +417,7 @@ const EbkpCostForm: React.FC<Props> = ({
       // Convert to numbers for arithmetic operations
       const numA = typeof aValue === 'number' ? aValue : 0;
       const numB = typeof bValue === 'number' ? bValue : 0;
-      
+
       if (sortDirection === 'asc') {
         return numA - numB;
       } else {
@@ -459,11 +459,11 @@ const EbkpCostForm: React.FC<Props> = ({
         <Typography variant="h6" color="primary">
           Kennwerte nach {
             groupingStrategy === 'ebkp' ? 'eBKP' :
-            groupingStrategy === 'ifc_class' ? 'IFC-Klasse' :
-            groupingStrategy === 'type_name' ? 'Typ-Name' :
-            groupingStrategy === 'level' ? 'Ebene' :
-            groupingStrategy === 'material' ? 'Material' :
-            groupingStrategy === 'structural' ? 'Tragwerk' : 'Gruppe'
+              groupingStrategy === 'ifc_class' ? 'IFC-Klasse' :
+                groupingStrategy === 'type_name' ? 'Typ-Name' :
+                  groupingStrategy === 'level' ? 'Ebene' :
+                    groupingStrategy === 'material' ? 'Material' :
+                      groupingStrategy === 'structural' ? 'Tragwerk' : 'Gruppe'
           }
         </Typography>
       </Box>
@@ -487,7 +487,7 @@ const EbkpCostForm: React.FC<Props> = ({
               <MenuItem value="structural">Tragwerk</MenuItem>
             </Select>
           </FormControl>
-          
+
           <Typography variant="body2" color="text.secondary">
             {filteredAndSortedData.length} Gruppen
           </Typography>
@@ -583,10 +583,10 @@ const EbkpCostForm: React.FC<Props> = ({
               >
                 {uniqueQuantityTypes.map((type) => (
                   <MenuItem key={type} value={type}>
-                    {type === 'area' ? 'Fläche' : 
-                     type === 'length' ? 'Länge' : 
-                     type === 'volume' ? 'Volumen' : 
-                     type === 'count' ? 'Stück' : type}
+                    {type === 'area' ? 'Fläche' :
+                      type === 'length' ? 'Länge' :
+                        type === 'volume' ? 'Volumen' :
+                          type === 'count' ? 'Stück' : type}
                   </MenuItem>
                 ))}
               </Select>
@@ -633,16 +633,16 @@ const EbkpCostForm: React.FC<Props> = ({
             <Typography variant="body2" color="text.secondary">
               Sortiert nach {
                 sortField === 'group' ? 'Gruppe' :
-                sortField === 'quantity' ? 'Menge' :
-                sortField === 'cost' ? 'Gesamtkosten' :
-                sortField === 'kennwert' ? 'Kennwert' :
-                sortField === 'element_count' ? 'Anzahl' : sortField
+                  sortField === 'quantity' ? 'Menge' :
+                    sortField === 'cost' ? 'Gesamtkosten' :
+                      sortField === 'kennwert' ? 'Kennwert' :
+                        sortField === 'element_count' ? 'Anzahl' : sortField
               } {sortDirection === 'asc' ? '↑' : '↓'}
             </Typography>
             {(() => {
               const groupsWithMissingQuantities = filteredAndSortedData.filter(group => hasGroupMissingQuantities(group)).length;
               return groupsWithMissingQuantities > 0 ? (
-                <Chip 
+                <Chip
                   label={`${groupsWithMissingQuantities} mit fehlenden Mengen`}
                   size="small"
                   color="warning"
@@ -748,287 +748,287 @@ const EbkpCostForm: React.FC<Props> = ({
               )}
             </Paper>
           ) : (
-          filteredAndSortedData.map((group) => {
-            const selectedQuantity = getSelectedQuantity(group);
-            const hasZeroQuantity = hasGroupMissingQuantities(group);
-            
-            return (
-              <Tooltip 
-                key={group.groupKey}
-                title={hasZeroQuantity ? `Enthält Elemente ohne ${selectedQuantity.label || selectedQuantity.type} - Gruppe ${group.displayName}` : ''}
-                arrow
-                placement="left"
-              >
-                <Paper 
-                  elevation={2}
-                  sx={getZeroQuantityStyles(hasZeroQuantity, { 
-                    p: 3,
-                    transition: 'all 0.3s ease-in-out',
-                    '&:hover': { 
-                      elevation: 4,
-                      transform: 'translateY(-2px)',
-                      boxShadow: '0 8px 25px rgba(0,0,0,0.15)'
-                    },
-                    background: 'linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%)',
-                    border: '1px solid',
-                    borderColor: 'divider'
-                  })}
+            filteredAndSortedData.map((group) => {
+              const selectedQuantity = getSelectedQuantity(group);
+              const hasZeroQuantity = hasGroupMissingQuantities(group);
+
+              return (
+                <Tooltip
+                  key={group.groupKey}
+                  title={hasZeroQuantity ? `Enthält Elemente ohne ${selectedQuantity.label || selectedQuantity.type} - Gruppe ${group.displayName}` : ''}
+                  arrow
+                  placement="left"
                 >
-                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 3 }}>
-                  {/* Group Code Badge */}
-                  <Box sx={{ minWidth: 80 }}>
-                    <Chip 
-                      label={group.displayName}
-                      color="primary"
-                      variant="filled"
-                      sx={{ 
-                        fontWeight: 'bold',
-                        fontSize: '0.875rem',
-                        height: 32,
-                        '& .MuiChip-label': { px: 2 }
-                      }}
-                    />
-                    {group.elements.length > 0 && (
-                      <Box sx={{ mt: 0.5 }}>
-                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                          {group.elements.length} Element{group.elements.length !== 1 ? 'e' : ''}
-                        </Typography>
-                        {hasZeroQuantity && (
-                          <Typography variant="caption" sx={{ 
-                            color: 'warning.main', 
+                  <Paper
+                    elevation={2}
+                    sx={getZeroQuantityStyles(hasZeroQuantity, {
+                      p: 3,
+                      transition: 'all 0.3s ease-in-out',
+                      '&:hover': {
+                        elevation: 4,
+                        transform: 'translateY(-2px)',
+                        boxShadow: '0 8px 25px rgba(0,0,0,0.15)'
+                      },
+                      background: 'linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%)',
+                      border: '1px solid',
+                      borderColor: 'divider'
+                    })}
+                  >
+                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 3 }}>
+                      {/* Group Code Badge */}
+                      <Box sx={{ minWidth: 80 }}>
+                        <Chip
+                          label={group.displayName}
+                          color="primary"
+                          variant="filled"
+                          sx={{
                             fontWeight: 'bold',
-                            fontSize: '0.65rem',
-                            display: 'block'
-                          }}>
-                            {(() => {
-                              const selectedQuantityType = group.selectedQuantityType || group.availableQuantities[0]?.type;
-                              const elementsWithMissingQuantities = group.elements.filter(element => {
-                                return hasElementMissingQuantity(element, selectedQuantityType);
-                              }).length;
-                              return `${elementsWithMissingQuantities} ohne Mengen`;
-                            })()}
-                          </Typography>
+                            fontSize: '0.875rem',
+                            height: 32,
+                            '& .MuiChip-label': { px: 2 }
+                          }}
+                        />
+                        {group.elements.length > 0 && (
+                          <Box sx={{ mt: 0.5 }}>
+                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                              {group.elements.length} Element{group.elements.length !== 1 ? 'e' : ''}
+                            </Typography>
+                            {hasZeroQuantity && (
+                              <Typography variant="caption" sx={{
+                                color: 'warning.main',
+                                fontWeight: 'bold',
+                                fontSize: '0.65rem',
+                                display: 'block'
+                              }}>
+                                {(() => {
+                                  const selectedQuantityType = group.selectedQuantityType || group.availableQuantities[0]?.type;
+                                  const elementsWithMissingQuantities = group.elements.filter(element => {
+                                    return hasElementMissingQuantity(element, selectedQuantityType);
+                                  }).length;
+                                  return `${elementsWithMissingQuantities} ohne Mengen`;
+                                })()}
+                              </Typography>
+                            )}
+                          </Box>
                         )}
                       </Box>
-                    )}
-                  </Box>
 
-                  {/* Quantity Selection */}
-                  <Box sx={{ flex: 1, minWidth: 300 }}>
-                    <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 'medium' }}>
-                      Mengenauswahl
-                    </Typography>
-                    {group.availableQuantities && group.availableQuantities.length > 1 ? (
-                      <FormControl fullWidth size="small">
-                        <Select
-                          value={group.selectedQuantityType || group.availableQuantities[0]?.type || ""}
-                          onChange={handleQuantityTypeChange(group.groupKey)}
-                          displayEmpty
-                          sx={{
-                            '& .MuiSelect-select': {
-                              py: 1.5,
-                              fontSize: '0.875rem',
-                              display: 'flex',
-                              alignItems: 'center'
-                            },
-                            '& .MuiOutlinedInput-root': {
-                              transition: 'all 0.2s ease-in-out',
-                              backgroundColor: 'background.paper',
-                              '&:hover': {
-                                boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
-                                backgroundColor: 'grey.50'
-                              },
-                              '&.Mui-focused': {
-                                boxShadow: '0 4px 12px rgba(25, 118, 210, 0.15)',
-                                backgroundColor: 'background.paper'
-                              }
-                            }
-                          }}
-                          renderValue={(value) => {
-                            const selected = group.availableQuantities?.find(q => q.type === value);
-                            if (!selected) return '';
-                            return (
-                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, width: '100%' }}>
-                                <Box sx={{ flex: 1 }}>
-                                  <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
-                                    {selected.label}
-                                  </Typography>
-                                  <Typography variant="caption" color="text.secondary">
-                                    {selected.type === 'area' ? 'Flächenberechnung' : 
-                                     selected.type === 'length' ? 'Längenberechnung' : 
-                                     selected.type === 'volume' ? 'Volumenberechnung' : 
-                                     selected.type === 'count' ? 'Stückzahl' : 'Andere'}
-                                  </Typography>
-                                </Box>
-                                <Chip 
-                                  label={`${selected.value.toLocaleString("de-CH")} ${selected.unit}`}
-                                  size="small"
-                                  color={hasZeroQuantity ? "warning" : "primary"}
-                                  variant="filled"
-                                  sx={{ 
-                                    fontWeight: 'bold', 
-                                    fontSize: '0.75rem',
-                                    color: hasZeroQuantity ? 'warning.contrastText' : 'primary.contrastText'
-                                  }}
-                                />
-                              </Box>
-                            );
-                          }}
-                        >
-                          {group.availableQuantities.map((qty) => (
-                            <MenuItem 
-                              key={qty.type} 
-                              value={qty.type}
-                              sx={{ 
-                                py: 2,
-                                '&:hover': { 
-                                  backgroundColor: 'primary.light',
-                                  '& .MuiChip-root': {
-                                    backgroundColor: 'primary.main',
-                                    color: 'white'
+                      {/* Quantity Selection */}
+                      <Box sx={{ flex: 1, minWidth: 300 }}>
+                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 'medium' }}>
+                          Mengenauswahl
+                        </Typography>
+                        {group.availableQuantities && group.availableQuantities.length > 1 ? (
+                          <FormControl fullWidth size="small">
+                            <Select
+                              value={group.selectedQuantityType || group.availableQuantities[0]?.type || ""}
+                              onChange={handleQuantityTypeChange(group.groupKey)}
+                              displayEmpty
+                              sx={{
+                                '& .MuiSelect-select': {
+                                  py: 1.5,
+                                  fontSize: '0.875rem',
+                                  display: 'flex',
+                                  alignItems: 'center'
+                                },
+                                '& .MuiOutlinedInput-root': {
+                                  transition: 'all 0.2s ease-in-out',
+                                  backgroundColor: 'background.paper',
+                                  '&:hover': {
+                                    boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+                                    backgroundColor: 'grey.50'
+                                  },
+                                  '&.Mui-focused': {
+                                    boxShadow: '0 4px 12px rgba(25, 118, 210, 0.15)',
+                                    backgroundColor: 'background.paper'
                                   }
                                 }
                               }}
+                              renderValue={(value) => {
+                                const selected = group.availableQuantities?.find(q => q.type === value);
+                                if (!selected) return '';
+                                return (
+                                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, width: '100%' }}>
+                                    <Box sx={{ flex: 1 }}>
+                                      <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                                        {selected.label}
+                                      </Typography>
+                                      <Typography variant="caption" color="text.secondary">
+                                        {selected.type === 'area' ? 'Flächenberechnung' :
+                                          selected.type === 'length' ? 'Längenberechnung' :
+                                            selected.type === 'volume' ? 'Volumenberechnung' :
+                                              selected.type === 'count' ? 'Stückzahl' : 'Andere'}
+                                      </Typography>
+                                    </Box>
+                                    <Chip
+                                      label={`${selected.value.toLocaleString("de-CH")} ${selected.unit}`}
+                                      size="small"
+                                      color={hasZeroQuantity ? "warning" : "primary"}
+                                      variant="filled"
+                                      sx={{
+                                        fontWeight: 'bold',
+                                        fontSize: '0.75rem',
+                                        color: hasZeroQuantity ? 'warning.contrastText' : 'primary.contrastText'
+                                      }}
+                                    />
+                                  </Box>
+                                );
+                              }}
                             >
-                              <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%', alignItems: 'center' }}>
-                                <Box>
-                                  <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
-                                    {qty.label}
-                                  </Typography>
-                                  <Typography variant="caption" color="text.secondary">
-                                    {qty.type === 'area' ? 'Flächenberechnung' : 
-                                     qty.type === 'length' ? 'Längenberechnung' : 
-                                     qty.type === 'volume' ? 'Volumenberechnung' : 
-                                     qty.type === 'count' ? 'Stückzahl' : 'Andere'}
-                                  </Typography>
-                                </Box>
-                                <Chip 
-                                  label={`${qty.value.toLocaleString("de-CH")} ${qty.unit}`}
-                                  size="small"
-                                  variant="outlined"
-                                  color={qty.type === (group.selectedQuantityType || group.availableQuantities?.[0]?.type) ? 'primary' : 'default'}
-                                  sx={{ ml: 1, fontSize: '0.75rem', fontWeight: 'bold' }}
-                                />
-                              </Box>
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-                    ) : group.availableQuantities && group.availableQuantities.length === 1 ? (
-                      <Box sx={{ 
-                        p: 1.5, 
-                        border: '1px solid', 
-                        borderColor: 'divider', 
-                        borderRadius: 1,
-                        backgroundColor: 'grey.50',
-                        display: 'flex', 
-                        alignItems: 'center', 
-                        justifyContent: 'space-between' 
-                      }}>
-                        <Box>
-                          <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
-                            {group.availableQuantities[0].label}
-                          </Typography>
-                          <Typography variant="caption" color="text.secondary">
-                            Einzige verfügbare Option
-                          </Typography>
-                        </Box>
-                        <Chip 
-                          label={`${group.availableQuantities[0].value.toLocaleString("de-CH")} ${group.availableQuantities[0].unit}`}
+                              {group.availableQuantities.map((qty) => (
+                                <MenuItem
+                                  key={qty.type}
+                                  value={qty.type}
+                                  sx={{
+                                    py: 2,
+                                    '&:hover': {
+                                      backgroundColor: 'primary.light',
+                                      '& .MuiChip-root': {
+                                        backgroundColor: 'primary.main',
+                                        color: 'white'
+                                      }
+                                    }
+                                  }}
+                                >
+                                  <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%', alignItems: 'center' }}>
+                                    <Box>
+                                      <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                                        {qty.label}
+                                      </Typography>
+                                      <Typography variant="caption" color="text.secondary">
+                                        {qty.type === 'area' ? 'Flächenberechnung' :
+                                          qty.type === 'length' ? 'Längenberechnung' :
+                                            qty.type === 'volume' ? 'Volumenberechnung' :
+                                              qty.type === 'count' ? 'Stückzahl' : 'Andere'}
+                                      </Typography>
+                                    </Box>
+                                    <Chip
+                                      label={`${qty.value.toLocaleString("de-CH")} ${qty.unit}`}
+                                      size="small"
+                                      variant="outlined"
+                                      color={qty.type === (group.selectedQuantityType || group.availableQuantities?.[0]?.type) ? 'primary' : 'default'}
+                                      sx={{ ml: 1, fontSize: '0.75rem', fontWeight: 'bold' }}
+                                    />
+                                  </Box>
+                                </MenuItem>
+                              ))}
+                            </Select>
+                          </FormControl>
+                        ) : group.availableQuantities && group.availableQuantities.length === 1 ? (
+                          <Box sx={{
+                            p: 1.5,
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            borderRadius: 1,
+                            backgroundColor: 'grey.50',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between'
+                          }}>
+                            <Box>
+                              <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                                {group.availableQuantities[0].label}
+                              </Typography>
+                              <Typography variant="caption" color="text.secondary">
+                                Einzige verfügbare Option
+                              </Typography>
+                            </Box>
+                            <Chip
+                              label={`${group.availableQuantities[0].value.toLocaleString("de-CH")} ${group.availableQuantities[0].unit}`}
+                              size="small"
+                              color={hasZeroQuantity ? "warning" : "primary"}
+                              variant="filled"
+                              sx={{
+                                fontWeight: 'bold',
+                                color: hasZeroQuantity ? 'warning.contrastText' : 'primary.contrastText'
+                              }}
+                            />
+                          </Box>
+                        ) : (
+                          <Box sx={{
+                            p: 1.5,
+                            border: '1px solid',
+                            borderColor: 'warning.main',
+                            borderRadius: 1,
+                            backgroundColor: 'warning.light',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center'
+                          }}>
+                            <Chip label="Keine Mengen verfügbar" size="small" color="warning" />
+                          </Box>
+                        )}
+                      </Box>
+
+                      {/* Cost Input and Calculation */}
+                      <Box sx={{ minWidth: 200 }}>
+                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 'medium' }}>
+                          Kennwert (CHF)
+                        </Typography>
+                        <TextField
+                          type="number"
+                          variant="outlined"
                           size="small"
-                          color={hasZeroQuantity ? "warning" : "primary"}
-                          variant="filled"
-                          sx={{ 
-                            fontWeight: 'bold',
-                            color: hasZeroQuantity ? 'warning.contrastText' : 'primary.contrastText'
+                          value={kennwerte[group.groupKey] ?? ""}
+                          onChange={handleChange(group.groupKey)}
+                          inputProps={{ step: "0.01", min: 0 }}
+                          fullWidth
+                          placeholder="0.00"
+                          sx={{
+                            '& .MuiOutlinedInput-root': {
+                              transition: 'all 0.2s ease-in-out',
+                              '&:hover': {
+                                boxShadow: '0 2px 8px rgba(0,0,0,0.1)'
+                              },
+                              '&.Mui-focused': {
+                                boxShadow: '0 4px 12px rgba(25, 118, 210, 0.15)'
+                              }
+                            }
                           }}
                         />
                       </Box>
-                    ) : (
-                      <Box sx={{ 
-                        p: 1.5, 
-                        border: '1px solid', 
-                        borderColor: 'warning.main', 
-                        borderRadius: 1,
-                        backgroundColor: 'warning.light',
-                        display: 'flex', 
-                        alignItems: 'center', 
-                        justifyContent: 'center' 
-                      }}>
-                        <Chip label="Keine Mengen verfügbar" size="small" color="warning" />
+
+                      {/* Total Cost Display */}
+                      <Box sx={{ minWidth: 150, textAlign: 'right' }}>
+                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 'medium' }}>
+                          Gesamtkosten
+                        </Typography>
+                        <Box sx={{
+                          p: 1.5,
+                          borderRadius: 1,
+                          backgroundColor: kennwerte[group.groupKey] ? 'success.light' : 'grey.100',
+                          border: '1px solid',
+                          borderColor: kennwerte[group.groupKey] ? 'success.main' : 'grey.300',
+                          minHeight: 40,
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center'
+                        }}>
+                          <Typography
+                            variant="h6"
+                            sx={{
+                              fontWeight: 'bold',
+                              color: kennwerte[group.groupKey] ? 'success.dark' : 'text.secondary',
+                              fontSize: '1rem'
+                            }}
+                          >
+                            {kennwerte[group.groupKey] && selectedQuantity
+                              ? `CHF ${(kennwerte[group.groupKey] * selectedQuantity.value).toLocaleString("de-CH", {
+                                maximumFractionDigits: 2,
+                              })}`
+                              : "CHF -"}
+                          </Typography>
+                        </Box>
                       </Box>
-                    )}
-                  </Box>
-
-                  {/* Cost Input and Calculation */}
-                  <Box sx={{ minWidth: 200 }}>
-                    <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 'medium' }}>
-                      Kennwert (CHF)
-      </Typography>
-                <TextField
-                  type="number"
-                  variant="outlined"
-                  size="small"
-                      value={kennwerte[group.groupKey] ?? ""}
-                      onChange={handleChange(group.groupKey)}
-                  inputProps={{ step: "0.01", min: 0 }}
-                      fullWidth
-                      placeholder="0.00"
-                      sx={{
-                        '& .MuiOutlinedInput-root': {
-                          transition: 'all 0.2s ease-in-out',
-                          '&:hover': {
-                            boxShadow: '0 2px 8px rgba(0,0,0,0.1)'
-                          },
-                          '&.Mui-focused': {
-                            boxShadow: '0 4px 12px rgba(25, 118, 210, 0.15)'
-                          }
-                        }
-                      }}
-                    />
-                  </Box>
-
-                  {/* Total Cost Display */}
-                  <Box sx={{ minWidth: 150, textAlign: 'right' }}>
-                    <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block', fontWeight: 'medium' }}>
-                      Gesamtkosten
-                    </Typography>
-                    <Box sx={{ 
-                      p: 1.5, 
-                      borderRadius: 1,
-                      backgroundColor: kennwerte[group.groupKey] ? 'success.light' : 'grey.100',
-                      border: '1px solid',
-                      borderColor: kennwerte[group.groupKey] ? 'success.main' : 'grey.300',
-                      minHeight: 40,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center'
-                    }}>
-                      <Typography 
-                        variant="h6" 
-                        sx={{ 
-                          fontWeight: 'bold', 
-                          color: kennwerte[group.groupKey] ? 'success.dark' : 'text.secondary',
-                          fontSize: '1rem'
-                        }}
-                      >
-                        {kennwerte[group.groupKey] && selectedQuantity
-                          ? `CHF ${(kennwerte[group.groupKey] * selectedQuantity.value).toLocaleString("de-CH", {
-                      maximumFractionDigits: 2,
-                            })}`
-                          : "CHF -"}
-                      </Typography>
                     </Box>
-                  </Box>
-                </Box>
-              </Paper>
-            </Tooltip>
-            );
-          })
+                  </Paper>
+                </Tooltip>
+              );
+            })
           )}
         </Box>
       )}
-      
+
     </Box>
   );
 };

--- a/src/components/ExcelDialog.tsx
+++ b/src/components/ExcelDialog.tsx
@@ -95,13 +95,13 @@ const ExcelDialog: React.FC<Props> = ({
       fileName: `Kostenkennwerte_${new Date().toISOString().split('T')[0]}`
     }
   );
-  
+
   const [isExporting, setIsExporting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const [importResult, setImportResult] = useState<ExcelImportResult | null>(null);
   const [importStep, setImportStep] = useState(0);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [previewData, setPreviewData] = useState<any[]>([]);
+  const [previewData, setPreviewData] = useState<Array<{ ebkpCode: string; kennwert: number | null | undefined }>>([]);
 
   // Update internal config when external config changes
   React.useEffect(() => {
@@ -149,13 +149,13 @@ const ExcelDialog: React.FC<Props> = ({
 
   const handleImport = useCallback(async () => {
     if (!selectedFile) return;
-    
+
     setIsImporting(true);
     try {
       const result = await ExcelService.importFromExcel(selectedFile);
       setImportResult(result);
       setImportStep(2);
-      
+
       if (result.success) {
         // Generate preview data
         const preview = result.data.slice(0, 10).map(item => ({
@@ -179,17 +179,17 @@ const ExcelDialog: React.FC<Props> = ({
 
   const handleApplyImport = useCallback(() => {
     if (!importResult?.success) return;
-    
+
     const newKennwerte: Record<string, number> = {};
     importResult.data.forEach(item => {
       if (item.kennwert !== undefined && item.kennwert !== null) {
         newKennwerte[item.groupKey] = item.kennwert;
       }
     });
-    
+
     onImportData(newKennwerte);
     setImportStep(3);
-    
+
     // Close dialog after a brief delay
     setTimeout(() => {
       onClose();
@@ -227,34 +227,34 @@ const ExcelDialog: React.FC<Props> = ({
           <Close />
         </IconButton>
       </DialogTitle>
-      
+
       <DialogContent sx={{ p: 0 }}>
         <Tabs value={activeTab} onChange={handleTabChange} sx={{ borderBottom: 1, borderColor: 'divider' }}>
-          <Tab 
-            label="Export" 
-            icon={<FileDownload />} 
+          <Tab
+            label="Export"
+            icon={<FileDownload />}
             iconPosition="start"
             sx={{ minHeight: 60 }}
           />
-          <Tab 
-            label="Import" 
-            icon={<FileUpload />} 
+          <Tab
+            label="Import"
+            icon={<FileUpload />}
             iconPosition="start"
             sx={{ minHeight: 60 }}
           />
         </Tabs>
 
-                <TabPanel value={activeTab} index={0}>
+        <TabPanel value={activeTab} index={0}>
           <Box sx={{ px: 3 }}>
             <Typography variant="h6" sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 1 }}>
               <Settings />
               Excel Export
             </Typography>
-            
+
             <Alert severity="info" sx={{ mb: 3 }}>
               Exportiert alle eBKP-Codes mit aktuellen Kennwerten. Sie können die Kennwerte in Excel bearbeiten und dann wieder importieren.
             </Alert>
-            
+
             <Box sx={{ mb: 4 }}>
               <TextField
                 label="Dateiname"
@@ -311,8 +311,8 @@ const ExcelDialog: React.FC<Props> = ({
                       </Button>
                     </label>
                     {selectedFile && (
-                      <Chip 
-                        label={selectedFile.name} 
+                      <Chip
+                        label={selectedFile.name}
                         onDelete={() => setSelectedFile(null)}
                         color="primary"
                       />
@@ -351,7 +351,7 @@ const ExcelDialog: React.FC<Props> = ({
                           <Alert severity="success" sx={{ mb: 2 }}>
                             <strong>{importResult.data.length} Datensätze</strong> erfolgreich gelesen
                           </Alert>
-                          
+
                           {importResult.warnings.length > 0 && (
                             <Alert severity="warning" sx={{ mb: 2 }}>
                               <Typography variant="subtitle2">Warnungen:</Typography>

--- a/src/components/SmartExcelButton.tsx
+++ b/src/components/SmartExcelButton.tsx
@@ -88,7 +88,7 @@ const SmartExcelButton: React.FC<Props> = ({
     handleClose();
     try {
       await onExport();
-    } catch (error) {
+    } catch {
       setProcessState('error');
       setToastMessage('Export fehlgeschlagen. Bitte versuchen Sie es erneut.');
       setToastSeverity('error');
@@ -160,9 +160,9 @@ const SmartExcelButton: React.FC<Props> = ({
     <>
       <Box sx={{ position: 'relative' }}>
         <ButtonGroup variant="outlined" size="medium">
-          <Tooltip 
+          <Tooltip
             title={
-              hasActivity 
+              hasActivity
                 ? `${exportCount} Exporte, ${importCount} Importe`
                 : 'Excel Export/Import'
             }
@@ -227,12 +227,12 @@ const SmartExcelButton: React.FC<Props> = ({
             sx: {
               mt: 1,
               minWidth: 320,
-              boxShadow: (theme) => theme.palette.mode === 'dark' 
-                ? '0 8px 32px rgba(0,0,0,0.8)' 
+              boxShadow: (theme) => theme.palette.mode === 'dark'
+                ? '0 8px 32px rgba(0,0,0,0.8)'
                 : '0 8px 32px rgba(0,0,0,0.12)',
               border: '1px solid',
-              borderColor: (theme) => theme.palette.mode === 'dark' 
-                ? 'rgba(255, 255, 255, 0.23)' 
+              borderColor: (theme) => theme.palette.mode === 'dark'
+                ? 'rgba(255, 255, 255, 0.23)'
                 : 'divider'
             }
           }}
@@ -250,7 +250,7 @@ const SmartExcelButton: React.FC<Props> = ({
             <ListItemIcon>
               <FileDownload color="primary" />
             </ListItemIcon>
-            <ListItemText 
+            <ListItemText
               primary="Nach Excel exportieren"
               secondary="Direkt herunterladen - keine weitere Konfiguration nötig"
             />
@@ -260,7 +260,7 @@ const SmartExcelButton: React.FC<Props> = ({
             <ListItemIcon>
               <FileUpload color="secondary" />
             </ListItemIcon>
-            <ListItemText 
+            <ListItemText
               primary="Aus Excel importieren"
               secondary="Datei auswählen und Vorschau anzeigen"
             />
@@ -268,44 +268,44 @@ const SmartExcelButton: React.FC<Props> = ({
 
           {(lastExportTime || lastImportTime) && (
             <>
-              <Box sx={{ 
-                px: 2, 
-                py: 1.5, 
-                backgroundColor: (theme) => theme.palette.mode === 'dark' 
-                  ? 'rgba(255, 255, 255, 0.08)' 
+              <Box sx={{
+                px: 2,
+                py: 1.5,
+                backgroundColor: (theme) => theme.palette.mode === 'dark'
+                  ? 'rgba(255, 255, 255, 0.08)'
                   : 'grey.50',
-                borderTop: '1px solid', 
-                borderColor: (theme) => theme.palette.mode === 'dark' 
-                  ? 'rgba(255, 255, 255, 0.23)' 
-                  : 'divider' 
+                borderTop: '1px solid',
+                borderColor: (theme) => theme.palette.mode === 'dark'
+                  ? 'rgba(255, 255, 255, 0.23)'
+                  : 'divider'
               }}>
                 <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, mb: 1, display: 'block' }}>
                   Letzte Aktivität
                 </Typography>
-                
+
                 {lastExportTime && (
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
                     <FileDownload sx={{ fontSize: 14, color: 'text.secondary' }} />
                     <Typography variant="caption" color="text.secondary">
-                      Export: {lastExportTime.toLocaleString('de-DE', { 
-                        day: '2-digit', 
-                        month: '2-digit', 
-                        hour: '2-digit', 
-                        minute: '2-digit' 
+                      Export: {lastExportTime.toLocaleString('de-DE', {
+                        day: '2-digit',
+                        month: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit'
                       })}
                     </Typography>
                   </Box>
                 )}
-                
+
                 {lastImportTime && (
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                     <FileUpload sx={{ fontSize: 14, color: 'text.secondary' }} />
                     <Typography variant="caption" color="text.secondary">
-                      Import: {lastImportTime.toLocaleString('de-DE', { 
-                        day: '2-digit', 
-                        month: '2-digit', 
-                        hour: '2-digit', 
-                        minute: '2-digit' 
+                      Import: {lastImportTime.toLocaleString('de-DE', {
+                        day: '2-digit',
+                        month: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit'
                       })}
                     </Typography>
                   </Box>
@@ -334,9 +334,9 @@ const SmartExcelButton: React.FC<Props> = ({
         onClose={handleToastClose}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
       >
-        <Alert 
-          onClose={handleToastClose} 
-          severity={toastSeverity} 
+        <Alert
+          onClose={handleToastClose}
+          severity={toastSeverity}
           variant="filled"
           sx={{ width: '100%' }}
         >

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -10,6 +10,7 @@ import logger from '../utils/logger';
 import { CostItem } from "../components/CostUploader/types";
 import { costApi } from "../services/costApi";
 import type { BackendElement as ApiBackendElement } from "../services/costApi";
+import { computeItemTotal } from "../utils/costTotals";
 
 // Define types for cost items
 interface MongoElement {
@@ -254,8 +255,7 @@ export const ApiProvider: React.FC<ApiProviderProps> = ({ children }) => {
 
   // Function to calculate updated CHF value
   const calculateUpdatedChf = (item: CostItem): number => {
-    if (!item.menge || !item.kennwert) return 0;
-    return item.menge * item.kennwert;
+    return computeItemTotal(item);
   };
 
   // Function to format timestamp

--- a/src/hooks/useCostCalculation.ts
+++ b/src/hooks/useCostCalculation.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
-import { CostItem } from "../components/CostUploader/types"; // Adjust path as needed
+import { CostItem } from "../components/CostUploader/types";
+import { computeItemTotal } from "../utils/costTotals";
 
 // Helper function to get all items from a hierarchical structure (recursive)
 const getAllItems = (items: CostItem[]): CostItem[] => {
@@ -7,7 +8,7 @@ const getAllItems = (items: CostItem[]): CostItem[] => {
   for (const item of items) {
     result.push(item);
     if (item.children && item.children.length > 0) {
-      result = result.concat(getAllItems(item.children));
+      result.push(...getAllItems(item.children));
     }
   }
   return result;
@@ -20,7 +21,7 @@ interface CostCalculationResult {
 
 /**
  * Custom hook to calculate total cost from hierarchical CostItem data.
- * It flattens the hierarchy and sums the 'chf' or 'totalChf' field.
+ * Sums top-level items using: totalChf → (menge × kennwert) → chf (nullish-aware to keep 0).
  * @param hierarchicalData The hierarchical array of CostItems.
  * @returns An object containing the totalCost and the flatItems array.
  */
@@ -32,24 +33,11 @@ export const useCostCalculation = (
       return { totalCost: 0, flatItems: [] };
     }
 
-    // Calculate totalCost by summing ONLY the top-level items.
-    // Prefer the explicit total (totalChf). If absent, fall back to
-    // quantity × unit cost, and finally to chf. Use nullish checks so 0 is valid.
-    const totalCost = hierarchicalData.reduce((sum, item) => {
-      const fromTotal = item.totalChf ?? null;
-      const fromQtyUnit =
-        item.menge != null && item.kennwert != null
-          ? item.menge * item.kennwert
-          : null;
-      const fromChf = item.chf ?? null;
-
-      const itemTotal =
-        (fromTotal != null ? fromTotal : null) ??
-        (fromQtyUnit != null ? fromQtyUnit : null) ??
-        (fromChf != null ? fromChf : 0);
-
-      return sum + (typeof itemTotal === "number" ? itemTotal : 0);
-    }, 0);
+    // Calculate totalCost by summing ONLY the top-level items using centralized logic
+    const totalCost = hierarchicalData.reduce(
+      (sum, item) => sum + computeItemTotal(item),
+      0
+    );
 
     // We still might want the flat list for other purposes, so calculate it separately.
     const flatItems = getAllItems(hierarchicalData);

--- a/src/hooks/useCostCalculation.ts
+++ b/src/hooks/useCostCalculation.ts
@@ -4,7 +4,7 @@ import { computeItemTotal } from "../utils/costTotals";
 
 // Helper function to get all items from a hierarchical structure (recursive)
 const getAllItems = (items: CostItem[]): CostItem[] => {
-  let result: CostItem[] = [];
+  const result: CostItem[] = [];
   for (const item of items) {
     result.push(item);
     if (item.children && item.children.length > 0) {
@@ -21,7 +21,7 @@ interface CostCalculationResult {
 
 /**
  * Custom hook to calculate total cost from hierarchical CostItem data.
- * Sums top-level items using: totalChf → (menge × kennwert) → chf (nullish-aware to keep 0).
+ * Sums top-level items using centralized logic: groups = sum(children); leaves = (area || menge) × kennwert.
  * @param hierarchicalData The hierarchical array of CostItems.
  * @returns An object containing the totalCost and the flatItems array.
  */

--- a/src/hooks/useEbkpGroups.ts
+++ b/src/hooks/useEbkpGroups.ts
@@ -5,7 +5,7 @@ import { EbkpStat } from '../components/EbkpCostForm';
 // Main EBKP group names mapping
 const EBKP_MAIN_GROUP_NAMES: Record<string, string> = {
   A: "Grundstück",
-  B: "Vorbereitung", 
+  B: "Vorbereitung",
   C: "Konstruktion",
   D: "Technik",
   E: "Äussere Wandbekleidung",
@@ -57,11 +57,11 @@ export const useEbkpGroups = (
 
     // Create hierarchical groups
     const hierarchicalMap = new Map<string, HierarchicalCostEbkpGroup>();
-    
+
     ebkpGroups.forEach((group) => {
       // Check if this is an EBKP code
       const mainGroup = getMainGroupFromEbkpCode(group.code);
-      
+
       if (mainGroup) {
         // It's an EBKP code - add to hierarchical structure
         if (!hierarchicalMap.has(mainGroup)) {
@@ -74,7 +74,7 @@ export const useEbkpGroups = (
             totalCost: 0,
           });
         }
-        
+
         const hierarchicalGroup = hierarchicalMap.get(mainGroup)!;
         hierarchicalGroup.subGroups.push(group);
         hierarchicalGroup.totalElements += group.elements.length;
@@ -92,7 +92,7 @@ export const useEbkpGroups = (
             totalCost: 0,
           });
         }
-        
+
         const otherGroup = hierarchicalMap.get("_OTHER_")!;
         otherGroup.subGroups.push(group);
         otherGroup.totalElements += group.elements.length;

--- a/src/hooks/useExcelDialog.ts
+++ b/src/hooks/useExcelDialog.ts
@@ -57,7 +57,12 @@ export const useExcelDialog = () => {
   useEffect(() => {
     try {
       // Don't save the filename as it should be date-based
-      const { fileName, ...configToSave } = exportConfig;
+      const configToSave = Object.keys(exportConfig).reduce((acc, key) => {
+        if (key !== 'fileName') {
+          acc[key] = exportConfig[key as keyof typeof exportConfig];
+        }
+        return acc;
+      }, {} as typeof exportConfig);
       localStorage.setItem(EXCEL_CONFIG_KEY, JSON.stringify(configToSave));
     } catch (error) {
       console.warn('Failed to save Excel config to localStorage:', error);
@@ -74,9 +79,9 @@ export const useExcelDialog = () => {
   }, [activity]);
 
   const openDialog = () => setIsOpen(true);
-  
+
   const closeDialog = () => setIsOpen(false);
-  
+
   const updateExportConfig = (config: Partial<ExcelExportConfig>) => {
     setExportConfig(prev => ({ ...prev, ...config }));
   };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import StandaloneApp from "./StandaloneApp.tsx";
+import StandaloneApp from "./StandaloneApp";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/utils/costTotals.test.ts
+++ b/src/utils/costTotals.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { computeRowTotal, computeGroupTotal, computeItemTotal } from './costTotals';
+import type { CostItem } from '../components/CostUploader/types';
+
+describe('cost total calculations', () => {
+  it('row calculation', () => {
+    expect(computeRowTotal(250, 3)).toBe(750);
+  });
+
+  it('group aggregation', () => {
+    const rows = [
+      { unitPrice: 100, quantity: 2 },
+      { unitPrice: 50, quantity: 1.5 },
+    ];
+    expect(computeGroupTotal(rows)).toBe(275);
+  });
+
+  it('view parity', () => {
+    const children: CostItem[] = [
+      { kennwert: 100, menge: 2 },
+      { kennwert: 50, menge: 1.5 },
+    ];
+    const group: CostItem = { children };
+    const expanded = children.reduce((sum, c) => sum + computeItemTotal(c), 0);
+    const collapsed = computeItemTotal(group);
+    expect(collapsed).toBe(expanded);
+  });
+
+  it('regression mismatch', () => {
+    const child: CostItem = { kennwert: 80, menge: 1, totalChf: 999 };
+    const group: CostItem = { children: [child], totalChf: 1234 };
+    expect(computeItemTotal(child)).toBe(80);
+    expect(computeItemTotal(group)).toBe(80);
+  });
+});

--- a/src/utils/costTotals.ts
+++ b/src/utils/costTotals.ts
@@ -21,14 +21,21 @@ export function computeItemTotal(item: CostItem): number {
     // Compute children first (will be cached individually)
     const childTotals: number[] = [];
     const childVersions: number[] = [];
+    const childSigs: string[] = [];
     for (const child of item.children as CostItem[]) {
       childTotals.push(computeItemTotal(child));
       const childEntry = itemTotalCache.get(child);
       childVersions.push(childEntry?.version ?? 0);
+      if (childEntry?.signature) {
+        childSigs.push(childEntry.signature);
+      } else {
+        // Rare fallback: child entry should exist after computeItemTotal(child)
+        childSigs.push(generateItemSignature(child));
+      }
     }
 
     const total = childTotals.reduce((sum, t) => sum + t, 0);
-    const signature = `g|c:${childVersions.join(',')}|len:${childVersions.length}`;
+    const signature = `g|cs:[${childSigs.sort().join(',')}]|len:${childVersions.length}`;
 
     const cached = itemTotalCache.get(item);
     if (cached && cached.signature === signature) {

--- a/src/utils/costTotals.ts
+++ b/src/utils/costTotals.ts
@@ -9,14 +9,109 @@ export function computeGroupTotal(rows: Array<{ unitPrice: number; quantity: num
 // Helper to compute total for hierarchical cost items
 import type { CostItem } from '../components/CostUploader/types';
 
-export function computeItemTotal(item: CostItem): number {
-  const quantity = item.menge ?? item.area ?? 0;
-  const unitPrice = item.kennwert ?? 0;
+// Memoization cache to avoid recomputing totals for the same item objects repeatedly
+// WeakMap ensures no memory leaks when items are garbage-collected
+type CacheEntry = { total: number; signature: string; version: number };
+const itemTotalCache: WeakMap<CostItem, CacheEntry> = new WeakMap();
 
-  if (item.children && item.children.length > 0) {
-    const childTotals = item.children.map((child) => computeItemTotal(child));
-    return computeGroupTotal(childTotals.map((t) => ({ unitPrice: 1, quantity: t })));
+export function computeItemTotal(item: CostItem): number {
+  const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+
+  if (hasChildren) {
+    // Compute children first (will be cached individually)
+    const childTotals: number[] = [];
+    const childVersions: number[] = [];
+    for (const child of item.children as CostItem[]) {
+      childTotals.push(computeItemTotal(child));
+      const childEntry = itemTotalCache.get(child);
+      childVersions.push(childEntry?.version ?? 0);
+    }
+
+    const total = childTotals.reduce((sum, t) => sum + t, 0);
+    const signature = `g|c:${childVersions.join(',')}|len:${childVersions.length}`;
+
+    const cached = itemTotalCache.get(item);
+    if (cached && cached.signature === signature) {
+      return cached.total;
+    }
+
+    const nextVersion = (cached?.signature === signature) ? (cached.version) : ((cached?.version ?? 0) + 1);
+    itemTotalCache.set(item, { total, signature, version: nextVersion });
+    return total;
   }
 
-  return computeRowTotal(unitPrice, quantity);
+  // Leaf row: prefer area over menge to align with UI quantity logic
+  const quantity = (item.area ?? item.menge ?? 0);
+  const unitPrice = item.kennwert ?? 0;
+  const total = computeRowTotal(unitPrice, quantity);
+  const signature = `l|u:${unitPrice}|q:${quantity}`;
+
+  const cached = itemTotalCache.get(item);
+  if (cached && cached.signature === signature) {
+    return cached.total;
+  }
+
+  const nextVersion = (cached?.signature === signature) ? (cached.version) : ((cached?.version ?? 0) + 1);
+  itemTotalCache.set(item, { total, signature, version: nextVersion });
+  return total;
+}
+
+/**
+ * Recursively aggregates area and element count from children
+ * Uses nullish coalescing to properly handle element_count of 0
+ * @param item The cost item to aggregate totals from
+ * @returns Object with area and elementCount totals
+ */
+export function aggregateChildTotals(item: CostItem): { area: number; elementCount: number } {
+  if (!item.children || item.children.length === 0) {
+    return { area: 0, elementCount: 0 };
+  }
+
+  return item.children.reduce<{ area: number; elementCount: number }>(
+    (acc, child) => {
+      if (child.children && child.children.length > 0) {
+        // Recursively aggregate from nested children
+        const childTotals = aggregateChildTotals(child);
+        acc.area += childTotals.area;
+        acc.elementCount += childTotals.elementCount;
+      } else {
+        // Leaf node: use area-first logic for quantity, nullish coalescing for element_count
+        const qty = child.area ?? child.menge ?? 0;
+        acc.area += qty;
+        acc.elementCount += child.element_count ?? 1;
+      }
+      return acc;
+    },
+    { area: 0, elementCount: 0 }
+  );
+}
+
+/**
+ * Generates a stable signature for deep change detection
+ * Creates a deterministic string representation of the item's relevant properties
+ * for use in React dependency arrays to detect deep tree changes
+ * @param item The cost item to generate signature for
+ * @returns A stable string signature of the item's structure and values
+ */
+export function generateItemSignature(item: CostItem): string {
+  // Create a stable signature focusing on properties that affect CHF calculations
+  const signatureParts: string[] = [
+    `ebkp:${item.ebkp || ''}`,
+    `kennwert:${item.kennwert || 0}`,
+    `area:${item.area || 0}`,
+    `menge:${item.menge || 0}`,
+  ];
+
+  // Recursively add child signatures in a deterministic order
+  if (item.children && item.children.length > 0) {
+    const childSignatures = item.children
+      .map(child => generateItemSignature(child))
+      .sort(); // Sort to ensure consistent ordering regardless of array order changes
+
+    signatureParts.push(`children:[${childSignatures.join(',')}]`);
+  } else {
+    signatureParts.push('children:[]');
+  }
+
+  return signatureParts.join('|');
 }

--- a/src/utils/costTotals.ts
+++ b/src/utils/costTotals.ts
@@ -1,0 +1,22 @@
+export function computeRowTotal(unitPrice: number, quantity: number): number {
+  return unitPrice * quantity;
+}
+
+export function computeGroupTotal(rows: Array<{ unitPrice: number; quantity: number }>): number {
+  return rows.reduce((acc, r) => acc + computeRowTotal(r.unitPrice, r.quantity), 0);
+}
+
+// Helper to compute total for hierarchical cost items
+import type { CostItem } from '../components/CostUploader/types';
+
+export function computeItemTotal(item: CostItem): number {
+  const quantity = item.menge ?? item.area ?? 0;
+  const unitPrice = item.kennwert ?? 0;
+
+  if (item.children && item.children.length > 0) {
+    const childTotals = item.children.map((child) => computeItemTotal(child));
+    return computeGroupTotal(childTotals.map((t) => ({ unitPrice: 1, quantity: t })));
+  }
+
+  return computeRowTotal(unitPrice, quantity);
+}

--- a/src/utils/quantityUtils.ts
+++ b/src/utils/quantityUtils.ts
@@ -46,4 +46,132 @@ export const hasElementMissingQuantity = (element: MongoElement, selectedQuantit
     default:
       return !element.area || element.area <= 0; // Default to area
   }
+};
+
+/**
+ * Maps quantity type to German label
+ * @param type - The quantity type ('area', 'volume', 'length', 'count')
+ * @returns The German label for the quantity type
+ */
+export const quantityTypeLabel = (type: string): string => {
+  switch (type) {
+    case 'area':
+      return 'Fläche';
+    case 'length':
+      return 'Länge';
+    case 'volume':
+      return 'Volumen';
+    case 'count':
+      return 'Stück';
+    default:
+      return type;
+  }
+};
+
+/**
+ * Maps quantity type to German calculation label
+ * @param type - The quantity type ('area', 'volume', 'length', 'count')
+ * @returns The German calculation label for the quantity type
+ */
+export const quantityTypeCalculationLabel = (type: string): string => {
+  switch (type) {
+    case 'area':
+      return 'Flächenberechnung';
+    case 'length':
+      return 'Längenberechnung';
+    case 'volume':
+      return 'Volumenberechnung';
+    case 'count':
+      return 'Stückzahl';
+    default:
+      return 'Andere';
+  }
+};
+
+/**
+ * Gets available quantities for a MongoElement
+ * @param el - The MongoElement to get available quantities for
+ * @returns Array of available quantities with value, type, unit, and label
+ */
+export const getAvailableQuantities = (el: MongoElement) => {
+  const quantities = [];
+
+  if (el.available_quantities && el.available_quantities.length > 0) {
+    return el.available_quantities;
+  }
+
+  const elAny = el as MongoElement & { area?: number; length?: number; volume?: number };
+
+  if (elAny.area && elAny.area > 0) {
+    quantities.push({
+      value: elAny.area,
+      type: "area",
+      unit: "m²",
+      label: "Area"
+    });
+  }
+
+  if (elAny.length && elAny.length > 0) {
+    quantities.push({
+      value: elAny.length,
+      type: "length",
+      unit: "m",
+      label: "Length"
+    });
+  }
+
+  if (elAny.volume && elAny.volume > 0) {
+    quantities.push({
+      value: elAny.volume,
+      type: "volume",
+      unit: "m³",
+      label: "Volume"
+    });
+  }
+
+  if (quantities.length === 0 || !quantities.some(q => q.type === 'count')) {
+    quantities.push({
+      value: 1,
+      type: "count",
+      unit: "Stk",
+      label: "Count"
+    });
+  }
+
+  return quantities;
+};
+
+/**
+ * Gets the selected quantity for a MongoElement based on selected type
+ * @param el - The MongoElement to get quantity for
+ * @param selectedType - The type of quantity to select (optional, defaults to first available)
+ * @returns Object with value, unit, and type of the selected quantity
+ */
+export const getSelectedQuantity = (
+  el: MongoElement,
+  selectedType?: string
+): { value: number; unit: string; type: string } => {
+  const availableQuantities = getAvailableQuantities(el);
+
+  if (availableQuantities.length === 0) {
+    return { value: 1, unit: "Stk", type: "count" };
+  }
+
+  if (selectedType) {
+    const selected = availableQuantities.find(q => q.type === selectedType);
+    if (selected) {
+      return {
+        value: selected.value,
+        unit: selected.unit,
+        type: selected.type
+      };
+    }
+  }
+
+  const defaultQty = availableQuantities[0];
+  return {
+    value: defaultQty.value,
+    unit: defaultQty.unit,
+    type: defaultQty.type
+  };
 }; 


### PR DESCRIPTION
## Summary
- centralize row and group total logic with new utilities
- compute table and preview totals from current child rows
- add tests for row, group, view parity, and regression scenarios

## Testing
- `npx vitest@3.2.4 --run`
- `npm run lint` *(fails: 'filteredElements' is never reassigned etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68adf9d96f748320ac7de17006dec15d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified, memoized CHF totals; BIM/QTO data source info with timestamps; dynamic unit/quantity selection and per-group expand/collapse; data-persistence UI and submit/export actions.

- **Bug Fixes**
  - More accurate totals by aggregating child items; quantities prefer aggregated area when present.

- **UI/UX**
  - Updated row/group styling, quantity chips, tooltips, copy-to-clipboard for GUIDs, and consistent CHF display.

- **Tests**
  - Added unit tests for cost calculation utilities.

- **Breaking Changes**
  - Public prop removed from item row; preview confirm payload shape changed; new context fields exposed (reapplyCostData, ebkpLoadError).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->