### PR TITLE
fix: unify row and group cost calculations

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build --mode production",
     "build:test": "tsc -b && vite build --mode test",
     "lint": "eslint .",
-    "preview": "vite preview --mode production"
+    "preview": "vite preview --mode production",
+    "test": "vitest run"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -18,7 +19,8 @@
     "exceljs": "^4.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.1.1"
+    "react-router-dom": "^7.1.1",
+    "vitest": "^3.2.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/src/components/CostUploader/CostTableChildRow.tsx
+++ b/src/components/CostUploader/CostTableChildRow.tsx
@@ -34,8 +34,6 @@ interface CellStyles {
 // Added interface for reducer accumulator
 interface ChildTotals {
   area: number;
-  cost: number;
-  chf: number;
   elementCount: number;
 }
 
@@ -145,42 +143,31 @@ const CostTableChildRow = ({
   // Update the calculateTotalsFromChildren function to handle grandchild sums
   const calculateTotalsFromChildren = (item: CostItem): ChildTotals => {
     if (!item.children || item.children.length === 0) {
-      return { area: 0, cost: 0, chf: 0, elementCount: 0 };
+      return { area: 0, elementCount: 0 };
     }
 
     return item.children.reduce<ChildTotals>(
       (acc, child) => {
-        // If child has direct area from MongoDB, add it
         if (child.area !== undefined) {
           acc.area += child.area;
-          acc.cost += child.area * (child.kennwert || 0);
-          acc.chf += child.area * (child.kennwert || 0);
-          // Only count elements at the leaf level (no children)
           if (!child.children || child.children.length === 0) {
             acc.elementCount += child.element_count || 1;
           }
         }
-        // If child has its own children (grandchildren), add their totals
         if (child.children && child.children.length > 0) {
           const childTotals = calculateTotalsFromChildren(child);
           acc.area += childTotals.area;
-          acc.cost += childTotals.cost;
-          acc.chf += childTotals.chf;
           acc.elementCount += childTotals.elementCount;
         }
-        // If child has no IFC data but has a menge, add it
         if (child.area === undefined && child.menge !== undefined) {
           acc.area += child.menge || 0;
-          acc.cost += (child.menge || 0) * (child.kennwert || 0);
-          acc.chf += (child.menge || 0) * (child.kennwert || 0);
-          // Only count non-IFC items at the leaf level
           if (!child.children || child.children.length === 0) {
             acc.elementCount += 1;
           }
         }
         return acc;
       },
-      { area: 0, cost: 0, chf: 0, elementCount: 0 }
+      { area: 0, elementCount: 0 }
     );
   };
 
@@ -200,15 +187,6 @@ const CostTableChildRow = ({
 
   // Update the getChfValue function to use grandchild sums
   const getChfValue = () => {
-    // Calculate total cost from grandchildren
-    const { chf } = calculateTotalsFromChildren(item);
-
-    // If we have a total cost from grandchildren, use it
-    if (chf > 0) {
-      return chf;
-    }
-
-    // Fallback to original calculation
     return calculateUpdatedChf(item);
   };
 

--- a/src/components/CostUploader/CostTableGrandchildRow.tsx
+++ b/src/components/CostUploader/CostTableGrandchildRow.tsx
@@ -61,17 +61,8 @@ const CostTableGrandchildRow = ({
     return originalMenge;
   };
 
-  // Get CHF value - calculate based on area when available
+  // Get CHF value
   const getChfValue = () => {
-    // If item has area from MongoDB
-    if (
-      item.area !== undefined &&
-      item.kennwert !== null &&
-      item.kennwert !== undefined
-    ) {
-      return item.area * item.kennwert;
-    }
-
     return calculateUpdatedChf(item);
   };
 

--- a/src/components/CostUploader/CostTableRow.tsx
+++ b/src/components/CostUploader/CostTableRow.tsx
@@ -150,45 +150,36 @@ const CostTableRow = ({
   // Update the calculateTotalsFromChildren function to fix TypeScript errors
   const calculateTotalsFromChildren = (
     item: CostItem
-  ): { area: number; cost: number; elementCount: number } => {
+  ): { area: number; elementCount: number } => {
     if (!item.children || item.children.length === 0) {
-      return { area: 0, cost: 0, elementCount: 0 };
+      return { area: 0, elementCount: 0 };
     }
 
     return item.children.reduce<{
       area: number;
-      cost: number;
       elementCount: number;
     }>(
       (acc, child) => {
-        // If child has direct area from MongoDB, add it
         if (child.area !== undefined) {
           acc.area += child.area;
-          acc.cost += child.area * (child.kennwert || 0);
-          // Only count elements at the leaf level (no children)
           if (!child.children || child.children.length === 0) {
             acc.elementCount += child.element_count || 1;
           }
         }
-        // If child has its own children, add their totals
         if (child.children && child.children.length > 0) {
           const childTotals = calculateTotalsFromChildren(child);
           acc.area += childTotals.area;
-          acc.cost += childTotals.cost;
           acc.elementCount += childTotals.elementCount;
         }
-        // If child has no IFC data but has a menge, add it
         if (child.area === undefined && child.menge !== undefined) {
           acc.area += child.menge || 0;
-          acc.cost += (child.menge || 0) * (child.kennwert || 0);
-          // Only count non-IFC items at the leaf level
           if (!child.children || child.children.length === 0) {
             acc.elementCount += 1;
           }
         }
         return acc;
       },
-      { area: 0, cost: 0, elementCount: 0 }
+      { area: 0, elementCount: 0 }
     );
   };
 
@@ -210,15 +201,6 @@ const CostTableRow = ({
 
   // Update the getChfValue function to calculate total CHF
   const getChfValue = (): number => {
-    // Calculate total cost from children
-    const { cost } = calculateTotalsFromChildren(item);
-
-    // If we have a total cost from children, use it
-    if (cost > 0) {
-      return cost;
-    }
-
-    // Fallback to original calculation
     return calculateUpdatedChf(item);
   };
 

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 import logger from '../utils/logger';
 import { CostItem } from "../components/CostUploader/types";
+import { computeCostItemTotal } from "../utils/costCalculations";
 import { costApi } from "../services/costApi";
 import type { BackendElement as ApiBackendElement } from "../services/costApi";
 
@@ -254,8 +255,7 @@ export const ApiProvider: React.FC<ApiProviderProps> = ({ children }) => {
 
   // Function to calculate updated CHF value
   const calculateUpdatedChf = (item: CostItem): number => {
-    if (!item.menge || !item.kennwert) return 0;
-    return item.menge * item.kennwert;
+    return computeCostItemTotal(item);
   };
 
   // Function to format timestamp

--- a/src/utils/costCalculations.test.ts
+++ b/src/utils/costCalculations.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeRowTotal,
+  computeGroupTotal,
+  computeCostItemTotal,
+} from "./costCalculations";
+import { CostItem } from "../components/CostUploader/types";
+
+describe("row calculation", () => {
+  it("multiplies unit price and quantity", () => {
+    expect(computeRowTotal(250, 3)).toBe(750);
+  });
+});
+
+describe("group aggregation", () => {
+  it("sums child row totals", () => {
+    const rows = [
+      { unitPrice: 100, quantity: 2 },
+      { unitPrice: 50, quantity: 1.5 },
+    ];
+    expect(computeGroupTotal(rows)).toBe(275);
+  });
+});
+
+describe("view parity", () => {
+  it("collapsed and expanded totals are identical", () => {
+    const item: CostItem = {
+      children: [
+        { kennwert: 100, menge: 2 },
+        { kennwert: 50, menge: 1.5 },
+      ],
+    };
+    const expandedTotal = item.children!
+      .map((c) => computeCostItemTotal(c))
+      .reduce((a, b) => a + b, 0);
+    const collapsedTotal = computeCostItemTotal(item);
+    expect(collapsedTotal).toBe(expandedTotal);
+  });
+});
+
+describe("regression", () => {
+  it("position price matches grand total", () => {
+    const item: CostItem = {
+      children: [
+        { kennwert: 120, menge: 1, chf: 999 },
+        { kennwert: 80, menge: 1 },
+      ],
+      totalChf: 555,
+    };
+    const childTotals = item.children!.map((c) => computeCostItemTotal(c));
+    const groupTotal = computeCostItemTotal(item);
+    expect(childTotals[0]).toBe(120);
+    expect(childTotals[1]).toBe(80);
+    expect(groupTotal).toBe(200);
+    expect(groupTotal).toBe(childTotals.reduce((a, b) => a + b, 0));
+  });
+});

--- a/src/utils/costCalculations.ts
+++ b/src/utils/costCalculations.ts
@@ -1,0 +1,19 @@
+import { CostItem } from "../components/CostUploader/types";
+
+export function computeRowTotal(unitPrice: number, quantity: number): number {
+  return unitPrice * quantity;
+}
+
+export function computeGroupTotal(rows: Array<{ unitPrice: number; quantity: number }>): number {
+  return rows.reduce((acc, r) => acc + computeRowTotal(r.unitPrice, r.quantity), 0);
+}
+
+export function computeCostItemTotal(item: CostItem): number {
+  if (item.children && item.children.length > 0) {
+    const totals = item.children.map((child) => computeCostItemTotal(child));
+    return computeGroupTotal(totals.map((total) => ({ unitPrice: 1, quantity: total })));
+  }
+  const unitPrice = item.kennwert ?? item.cost_unit ?? 0;
+  const quantity = item.area ?? item.menge ?? 0;
+  return computeRowTotal(unitPrice, quantity);
+}


### PR DESCRIPTION
## Summary
- compute row and group totals through shared helpers
- rely on shared cost calculations for cost table rows and groups
- add tests covering row, group and view parity cases

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, React Hook missing dependency, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68adf9d96f748320ac7de17006dec15d